### PR TITLE
Vergelijkingstool version 0

### DIFF
--- a/hhnk_threedi_tools/core/vergelijkingstool/DAMO.py
+++ b/hhnk_threedi_tools/core/vergelijkingstool/DAMO.py
@@ -1,17 +1,17 @@
-import logging
-import geopandas as gpd
-import pandas as pd
 import json
-import fiona
+import logging
 from pathlib import Path
 
-from datamodels.Dataset import DataSet
-from config import *
-from styling import *
+import fiona
+import geopandas as gpd
+import pandas as pd
+
+from hhnk_threedi_tools.core.vergelijkingstool.config import *
+from hhnk_threedi_tools.core.vergelijkingstool.Dataset import DataSet
+from hhnk_threedi_tools.core.vergelijkingstool.styling import *
 
 
 class DAMO(DataSet):
-
     def __init__(self, damo_filename, hdb_filename, translation_DAMO=None, translation_HDB=None, clip_shape=None):
         """
         Creates a DAMO object and reads the data from the DAMO and HDB FileGeoDatabase.
@@ -25,8 +25,8 @@ class DAMO(DataSet):
         """
 
         # Set up logger
-        self.logger = logging.getLogger('DAMO')
-        self.logger.debug('Created DAMO object')
+        self.logger = logging.getLogger("DAMO")
+        self.logger.debug("Created DAMO object")
 
         # Load data
         self.data = self.from_file(damo_filename, hdb_filename, translation_DAMO, translation_HDB)
@@ -85,10 +85,10 @@ class DAMO(DataSet):
                 if layer == layer_name:
                     # Map column names
                     self.logger.debug(f"Mapping column names of layer {layer}")
-                    data[layer].rename(columns=mapping[layer]['columns'], inplace=True)
+                    data[layer].rename(columns=mapping[layer]["columns"], inplace=True)
 
                     # Store layer mapping in dict to be mapped later
-                    translate_layers[layer_name] = mapping[layer]['name']
+                    translate_layers[layer_name] = mapping[layer]["name"]
 
         # Map layer names
         for old, new in translate_layers.items():
@@ -96,7 +96,13 @@ class DAMO(DataSet):
 
         return data
 
-    def from_file(self, damo_filename, hdb_filename, translation_DAMO=None, translation_HDB=None, ):
+    def from_file(
+        self,
+        damo_filename,
+        hdb_filename,
+        translation_DAMO=None,
+        translation_HDB=None,
+    ):
         """
         Function that loads the data in GeoDataFrames and applies layer and column mapping
 
@@ -111,7 +117,7 @@ class DAMO(DataSet):
         data = {}
 
         # Load layers within .gdb datasets
-        self.logger.debug('Find layer names within geopackages')
+        self.logger.debug("Find layer names within geopackages")
         layers_gdb_damo = fiona.listlayers(damo_filename)
         layers_gdb_hdb = fiona.listlayers(hdb_filename)
 
@@ -168,20 +174,22 @@ class DAMO(DataSet):
                     Path.unlink(filename)
                 except PermissionError:
                     self.logger.error(
-                        "File to export to is still in use. Unload GPKG from QGIS and disconnect database connections")
+                        "File to export to is still in use. Unload GPKG from QGIS and disconnect database connections"
+                    )
             else:
-                raise FileExistsError(f'The file "{filename}" already exists. If you want to overwrite the '
-                                      f'existing file, add overwrite=True to the function.')
+                raise FileExistsError(
+                    f'The file "{filename}" already exists. If you want to overwrite the '
+                    f"existing file, add overwrite=True to the function."
+                )
 
         # Deal with multiple geometry types per layer. Split each layer in a LayerName_Point or LayerName_LineString
         # and delete the original layer
         for layer_name in list(table_C):
             if len(table_C[layer_name].geometry.type.unique()) > 1:
                 for geometry_type in range(len(table_C[layer_name].geometry.type.unique())):
-                    table_C[f'{layer_name}_{table_C[layer_name].geometry.type.unique()[geometry_type]}'] = \
-                        table_C[layer_name][
-                            table_C[layer_name].geometry.type == table_C[layer_name].geometry.type.unique()[
-                                geometry_type]]
+                    table_C[f"{layer_name}_{table_C[layer_name].geometry.type.unique()[geometry_type]}"] = table_C[
+                        layer_name
+                    ][table_C[layer_name].geometry.type == table_C[layer_name].geometry.type.unique()[geometry_type]]
                 del table_C[layer_name]
 
         # Add an entry to the styling table. First check if a qml file exists with the same name as the layer.
@@ -199,25 +207,83 @@ class DAMO(DataSet):
                         style = file.read()
                         style_name = layer_name + "_style"
                         table.append(
-                            [i, None, None, layer_name, table_C[layer_name]._geometry_column_name, style_name,
-                             style, None, 'false', None, None, None, None])
+                            [
+                                i,
+                                None,
+                                None,
+                                layer_name,
+                                table_C[layer_name]._geometry_column_name,
+                                style_name,
+                                style,
+                                None,
+                                "false",
+                                None,
+                                None,
+                                None,
+                                None,
+                            ]
+                        )
                 else:
                     if table_C[layer_name].geometry.type.unique() is None:
                         pass
-                    if table_C[layer_name].geometry.type.drop_duplicates().to_list() == ['Point']:
+                    if table_C[layer_name].geometry.type.drop_duplicates().to_list() == ["Point"]:
                         table.append(
-                            [i, None, None, layer_name, table_C[layer_name]._geometry_column_name, 'point_style',
-                             STYLING_POINTS_DAMO, None, 'false', None, None, None, None])
-                    if table_C[layer_name].geometry.type.drop_duplicates().to_list() == ['LineString'] or table_C[
-                        layer_name].geometry.type.drop_duplicates().to_list() == ['MultiLineString']:
+                            [
+                                i,
+                                None,
+                                None,
+                                layer_name,
+                                table_C[layer_name]._geometry_column_name,
+                                "point_style",
+                                STYLING_POINTS_DAMO,
+                                None,
+                                "false",
+                                None,
+                                None,
+                                None,
+                                None,
+                            ]
+                        )
+                    if table_C[layer_name].geometry.type.drop_duplicates().to_list() == ["LineString"] or table_C[
+                        layer_name
+                    ].geometry.type.drop_duplicates().to_list() == ["MultiLineString"]:
                         table.append(
-                            [i, None, None, layer_name, table_C[layer_name]._geometry_column_name, 'line_style',
-                             STYLING_LINES_DAMO, None, 'false', None, None, None, None])
-                    if table_C[layer_name].geometry.type.drop_duplicates().to_list() == ['Polygon'] or table_C[
-                        layer_name].geometry.type.drop_duplicates().to_list() == ['MultiPolygon']:
+                            [
+                                i,
+                                None,
+                                None,
+                                layer_name,
+                                table_C[layer_name]._geometry_column_name,
+                                "line_style",
+                                STYLING_LINES_DAMO,
+                                None,
+                                "false",
+                                None,
+                                None,
+                                None,
+                                None,
+                            ]
+                        )
+                    if table_C[layer_name].geometry.type.drop_duplicates().to_list() == ["Polygon"] or table_C[
+                        layer_name
+                    ].geometry.type.drop_duplicates().to_list() == ["MultiPolygon"]:
                         table.append(
-                            [i, None, None, layer_name, table_C[layer_name]._geometry_column_name, 'polygon_style',
-                             STYLING_POLYGONS_DAMO, None, 'false', None, None, None, None])
+                            [
+                                i,
+                                None,
+                                None,
+                                layer_name,
+                                table_C[layer_name]._geometry_column_name,
+                                "polygon_style",
+                                STYLING_POLYGONS_DAMO,
+                                None,
+                                "false",
+                                None,
+                                None,
+                                None,
+                                None,
+                            ]
+                        )
 
             self.logger.info(f"export results of comparing DAMO/DAMO layer {layer_name} to geopackage")
             table_C[layer_name].to_file(filename, layer=layer_name, driver="GPKG")
@@ -252,7 +318,6 @@ class DAMO(DataSet):
 
         table_C = {}
         for layer in table_A.keys():
-
             if not table_B.keys().__contains__(layer):
                 self.logger.warning(f"Layer {layer} does not exist in the other dataset, skipping layer")
                 continue
@@ -274,48 +339,48 @@ class DAMO(DataSet):
                 table_B[layer] = self.add_geometry_info(table_B[layer])
 
                 # Add 'dataset' column, after merging this will become 'dataset_A' and 'dataset_B'
-                table_A[layer]['dataset'] = True
-                table_B[layer]['dataset'] = True
+                table_A[layer]["dataset"] = True
+                table_B[layer]["dataset"] = True
 
                 # Add layer of origin to dataset
-                table_A[layer]['origin'] = layer
-                table_B[layer]['origin'] = layer
+                table_A[layer]["origin"] = layer
+                table_B[layer]["origin"] = layer
 
                 # outer merge on the two tables with suffixes
-                table_A[layer] = table_A[layer].add_suffix('_A').rename(columns={'code_A': 'code'})
-                table_B[layer] = table_B[layer].add_suffix('_B').rename(columns={'code_B': 'code'})
+                table_A[layer] = table_A[layer].add_suffix("_A").rename(columns={"code_A": "code"})
+                table_B[layer] = table_B[layer].add_suffix("_B").rename(columns={"code_B": "code"})
 
-                #make sure the code column is of type string for proper merging
-                table_A[layer]['code'] = table_A[layer]['code'].astype('string')
-                table_B[layer]['code'] = table_B[layer]['code'].astype('string')
+                # make sure the code column is of type string for proper merging
+                table_A[layer]["code"] = table_A[layer]["code"].astype("string")
+                table_B[layer]["code"] = table_B[layer]["code"].astype("string")
 
-                table_merged = table_A[layer].merge(table_B[layer], how="outer", on='code') #Futurewarning
-                table_merged['geometry'] = None
-                table_merged = gpd.GeoDataFrame(table_merged, geometry='geometry')
+                table_merged = table_A[layer].merge(table_B[layer], how="outer", on="code")  # Futurewarning
+                table_merged["geometry"] = None
+                table_merged = gpd.GeoDataFrame(table_merged, geometry="geometry")
 
                 # fillna values of the two columns by False
-                table_merged[['dataset_A', 'dataset_B']] = table_merged[['dataset_A', 'dataset_B']].fillna(value=False)
+                table_merged[["dataset_A", "dataset_B"]] = table_merged[["dataset_A", "dataset_B"]].fillna(value=False)
 
                 # add column with values A, B or AB, depending on code
                 inboth = []
                 geometry_adjusted = []
                 for i in range(len(table_merged)):
-                    if table_merged['dataset_A'][i] & table_merged['dataset_B'][i]:
-                        inboth.append('AB')
+                    if table_merged["dataset_A"][i] & table_merged["dataset_B"][i]:
+                        inboth.append("AB")
                         # geometry_adjusted.append(table_merged['geometry_A'][i] != table_merged['geometry_B'][i])
-                    elif table_merged['dataset_A'][i] and not table_merged['dataset_B'][i]:
-                        inboth.append('A')
+                    elif table_merged["dataset_A"][i] and not table_merged["dataset_B"][i]:
+                        inboth.append("A")
                         # geometry_adjusted.append(None)
                     else:
-                        inboth.append('B')
+                        inboth.append("B")
                         # geometry_adjusted.append(None)
-                table_merged['in_both'] = inboth
-                table_merged['geometry_adjusted'] = (table_merged['geometry_A'] != table_merged['geometry_B'])
+                table_merged["in_both"] = inboth
+                table_merged["geometry_adjusted"] = table_merged["geometry_A"] != table_merged["geometry_B"]
 
                 # use geometry of A (new) when feature exists in A or in A and B, use geometry of B (old) when feature
                 # only exists in B
                 if layer in [x.lower() for x in GEOMETRICAL_COMPARISON_LAYERS]:
-                    if layer == 'waterdeel':
+                    if layer == "waterdeel":
                         # For waterdeel we cannot compare based on code. So we treat A and B as one big polygon and
                         # determine the intersection and the differences
                         union_A = table_merged.geometry_A.unary_union
@@ -324,60 +389,80 @@ class DAMO(DataSet):
                         diff_A = union_A.difference(union_B)
                         diff_B = union_B.difference(union_A)
 
-                        df_intersections = gpd.GeoDataFrame(gpd.GeoSeries([intersection, diff_A, diff_B])) \
-                            .rename(columns={0: "geometry"}).set_geometry('geometry')
-                        df_intersections['in_both'] = pd.Series(['AB', 'A', 'B'])
-                        df_intersections = df_intersections.explode(column='geometry', index_parts=True)
-                        table_merged = df_intersections[df_intersections.geometry.geom_type == 'Polygon'].copy()
+                        df_intersections = (
+                            gpd.GeoDataFrame(gpd.GeoSeries([intersection, diff_A, diff_B]))
+                            .rename(columns={0: "geometry"})
+                            .set_geometry("geometry")
+                        )
+                        df_intersections["in_both"] = pd.Series(["AB", "A", "B"])
+                        df_intersections = df_intersections.explode(column="geometry", index_parts=True)
+                        table_merged = df_intersections[df_intersections.geometry.geom_type == "Polygon"].copy()
 
-                        table_merged.loc[table_merged['in_both'].isin(['A', 'AB']), 'geom_area_A'] = table_merged[
-                            'geometry'].area
-                        table_merged.loc[~table_merged['in_both'].isin(['A', 'AB']), 'geom_area_A'] = None
+                        table_merged.loc[table_merged["in_both"].isin(["A", "AB"]), "geom_area_A"] = table_merged[
+                            "geometry"
+                        ].area
+                        table_merged.loc[~table_merged["in_both"].isin(["A", "AB"]), "geom_area_A"] = None
 
-                        table_merged.loc[table_merged['in_both'].isin(['B', 'AB']), 'geom_area_B'] = table_merged[
-                            'geometry'].area
-                        table_merged.loc[~table_merged['in_both'].isin(['B', 'AB']), 'geom_area_B'] = None
+                        table_merged.loc[table_merged["in_both"].isin(["B", "AB"]), "geom_area_B"] = table_merged[
+                            "geometry"
+                        ].area
+                        table_merged.loc[~table_merged["in_both"].isin(["B", "AB"]), "geom_area_B"] = None
 
-                        table_merged['geom_length_A'] = 0
-                        table_merged['geom_length_B'] = 0
+                        table_merged["geom_length_A"] = 0
+                        table_merged["geom_length_B"] = 0
                     else:
                         # hier iets om geometrieen te bepalen
-                        intersection = gpd.GeoDataFrame(pd.concat([table_merged.code, table_merged['geometry_A']
-                                                                  .intersection(table_merged['geometry_B'])], axis=1)) \
-                            .rename(columns={0: "geometry_diff"})
-                        intersection['origin'] = 'intersection'
-                        diff_A = gpd.GeoDataFrame(pd.concat([table_merged.code, table_merged['geometry_A']
-                                                            .difference(table_merged['geometry_B'])], axis=1)) \
-                            .rename(columns={0: "geometry_diff"})
-                        diff_A['origin'] = 'diff_A'
-                        diff_B = gpd.GeoDataFrame(pd.concat([table_merged.code, table_merged['geometry_B'].
-                                                            difference(table_merged['geometry_A'])], axis=1)). \
-                            rename(columns={0: "geometry_diff"})
-                        diff_B['origin'] = 'diff_B'
+                        intersection = gpd.GeoDataFrame(
+                            pd.concat(
+                                [
+                                    table_merged.code,
+                                    table_merged["geometry_A"].intersection(table_merged["geometry_B"]),
+                                ],
+                                axis=1,
+                            )
+                        ).rename(columns={0: "geometry_diff"})
+                        intersection["origin"] = "intersection"
+                        diff_A = gpd.GeoDataFrame(
+                            pd.concat(
+                                [table_merged.code, table_merged["geometry_A"].difference(table_merged["geometry_B"])],
+                                axis=1,
+                            )
+                        ).rename(columns={0: "geometry_diff"})
+                        diff_A["origin"] = "diff_A"
+                        diff_B = gpd.GeoDataFrame(
+                            pd.concat(
+                                [table_merged.code, table_merged["geometry_B"].difference(table_merged["geometry_A"])],
+                                axis=1,
+                            )
+                        ).rename(columns={0: "geometry_diff"})
+                        diff_B["origin"] = "diff_B"
 
                         df_intersections = pd.concat([intersection, diff_A, diff_B])
-                        df_intersections = df_intersections[df_intersections['geometry_diff'].notna()]
-                        table_merged = table_merged.merge(df_intersections, how="outer", on='code')
+                        df_intersections = df_intersections[df_intersections["geometry_diff"].notna()]
+                        table_merged = table_merged.merge(df_intersections, how="outer", on="code")
 
                         # table_merged = table_merged.explode(column='geometry_diff', index_parts=True)
                         # table_merged = table_merged[table_merged.geometry_diff.geom_type == 'Polygon']
 
-                        table_merged['geometry_diff'] = table_merged.apply(
-                            lambda x: self.get_significant_geometry(x['in_both'], x['geometry_A'], x['geometry_B']) if (
-                                    x['geometry_diff'] is None) else x['geometry_diff'], axis=1)
-                        table_merged['origin'].fillna(table_merged['in_both'], inplace=True)
-                        table_merged['geometry'] = table_merged['geometry_diff']
+                        table_merged["geometry_diff"] = table_merged.apply(
+                            lambda x: self.get_significant_geometry(x["in_both"], x["geometry_A"], x["geometry_B"])
+                            if (x["geometry_diff"] is None)
+                            else x["geometry_diff"],
+                            axis=1,
+                        )
+                        table_merged["origin"].fillna(table_merged["in_both"], inplace=True)
+                        table_merged["geometry"] = table_merged["geometry_diff"]
 
-                        table_merged = table_merged.explode(column='geometry', index_parts=True)
-                        table_merged = table_merged[table_merged.geometry.geom_type == 'Polygon']
+                        table_merged = table_merged.explode(column="geometry", index_parts=True)
+                        table_merged = table_merged[table_merged.geometry.geom_type == "Polygon"]
 
                 else:
-                    table_merged['geometry'] = table_merged.apply(
-                        lambda x: self.get_significant_geometry(x['in_both'], x['geometry_A'],
-                                                                x['geometry_B']), axis=1)
+                    table_merged["geometry"] = table_merged.apply(
+                        lambda x: self.get_significant_geometry(x["in_both"], x["geometry_A"], x["geometry_B"]), axis=1
+                    )
                 # remove all geometry columns except 'geometry'
-                table_merged = self.drop_unused_geoseries(table_merged, keep='geometry')
-                table_C[layer] = gpd.GeoDataFrame(table_merged, geometry='geometry', crs=crs)
+                table_merged = self.drop_unused_geoseries(table_merged, keep="geometry")
+                table_C[layer] = gpd.GeoDataFrame(table_merged, geometry="geometry", crs=crs)
 
             except KeyError as err:
                 self.logger.warning(f"Column {err.args[0]} not found in layer {layer}, skipping layer")
@@ -391,28 +476,65 @@ class DAMO(DataSet):
         # determine statistics: count amount of shapes per layer for dataset A and B
         self.logger.debug("create statistics")
         statistics = pd.DataFrame(
-            columns=['Count A', 'Count B', 'Count difference', 'Length A', 'Length B', 'Length difference', 'Area A',
-                     'Area B', 'Area difference'])
+            columns=[
+                "Count A",
+                "Count B",
+                "Count difference",
+                "Length A",
+                "Length B",
+                "Length difference",
+                "Area A",
+                "Area B",
+                "Area difference",
+            ]
+        )
         for i, layer_name in enumerate(table_C):
             self.logger.debug(f"Layer name: {layer_name}")
-            count_A = len(table_C[layer_name].loc[(table_C[layer_name]['in_both'] == 'A') |
-                                                  (table_C[layer_name]['in_both'] == 'AB')])
-            count_B = len(table_C[layer_name].loc[(table_C[layer_name]['in_both'] == 'B') |
-                                                  (table_C[layer_name]['in_both'] == 'AB')])
+            count_A = len(
+                table_C[layer_name].loc[
+                    (table_C[layer_name]["in_both"] == "A") | (table_C[layer_name]["in_both"] == "AB")
+                ]
+            )
+            count_B = len(
+                table_C[layer_name].loc[
+                    (table_C[layer_name]["in_both"] == "B") | (table_C[layer_name]["in_both"] == "AB")
+                ]
+            )
             count_diff = count_B - count_A
-            length_A = sum(table_C[layer_name].loc[(table_C[layer_name]['in_both'] == 'A') |
-                                                   (table_C[layer_name]['in_both'] == 'AB')].geom_length_A)
-            length_B = sum(table_C[layer_name].loc[(table_C[layer_name]['in_both'] == 'B') |
-                                                   (table_C[layer_name]['in_both'] == 'AB')].geom_length_B)
+            length_A = sum(
+                table_C[layer_name]
+                .loc[(table_C[layer_name]["in_both"] == "A") | (table_C[layer_name]["in_both"] == "AB")]
+                .geom_length_A
+            )
+            length_B = sum(
+                table_C[layer_name]
+                .loc[(table_C[layer_name]["in_both"] == "B") | (table_C[layer_name]["in_both"] == "AB")]
+                .geom_length_B
+            )
             length_diff = length_B - length_A
-            area_A = sum(table_C[layer_name].loc[(table_C[layer_name]['in_both'] == 'A') |
-                                                 (table_C[layer_name]['in_both'] == 'AB')].geom_area_A)
-            area_B = sum(table_C[layer_name].loc[(table_C[layer_name]['in_both'] == 'B') |
-                                                 (table_C[layer_name]['in_both'] == 'AB')].geom_area_B)
+            area_A = sum(
+                table_C[layer_name]
+                .loc[(table_C[layer_name]["in_both"] == "A") | (table_C[layer_name]["in_both"] == "AB")]
+                .geom_area_A
+            )
+            area_B = sum(
+                table_C[layer_name]
+                .loc[(table_C[layer_name]["in_both"] == "B") | (table_C[layer_name]["in_both"] == "AB")]
+                .geom_area_B
+            )
             area_diff = area_B - area_A
-            statistics.loc[layer_name, :] = [count_A, count_B, count_diff, length_A, length_B, length_diff, area_A,
-                                             area_B, area_diff]
-        statistics = statistics.fillna(0).astype('int64')
+            statistics.loc[layer_name, :] = [
+                count_A,
+                count_B,
+                count_diff,
+                length_A,
+                length_B,
+                length_diff,
+                area_A,
+                area_B,
+                area_diff,
+            ]
+        statistics = statistics.fillna(0).astype("int64")
 
         # check if filename already exists. Cr
         if filename is not None:

--- a/hhnk_threedi_tools/core/vergelijkingstool/DAMO.py
+++ b/hhnk_threedi_tools/core/vergelijkingstool/DAMO.py
@@ -1,0 +1,421 @@
+import logging
+import geopandas as gpd
+import pandas as pd
+import json
+import fiona
+from pathlib import Path
+
+from datamodels.Dataset import DataSet
+from config import *
+from styling import *
+
+
+class DAMO(DataSet):
+
+    def __init__(self, damo_filename, hdb_filename, translation_DAMO=None, translation_HDB=None, clip_shape=None):
+        """
+        Creates a DAMO object and reads the data from the DAMO and HDB FileGeoDatabase.
+        If translation dictionaries are supplied, layer and column names are mapped.
+
+        :param damo_filename: Path to the GDB folder with DAMO data.
+        :param hdb_filename: Path to the GDB folder with HDB data.
+        :param translation_DAMO: Path to the DAMO translation dictionary.
+        :param translation_HDB: Path to the HDB translation dictionary.
+        :param clip_shape: Shapely shape to subset data on
+        """
+
+        # Set up logger
+        self.logger = logging.getLogger('DAMO')
+        self.logger.debug('Created DAMO object')
+
+        # Load data
+        self.data = self.from_file(damo_filename, hdb_filename, translation_DAMO, translation_HDB)
+
+        # Set priority columns
+        self.priority_columns = {}
+
+        # Clip data
+        if clip_shape is not None:
+            self.data = self.clip_data(self.data, clip_shape)
+
+        # Add mapped layer names as DAMO attributes
+        for key in self.data.keys():
+            self.__setattr__(key, self.data[key])
+
+    def clip_data(self, data, shape):
+        """
+        Interates over all layers within the DAMO/HDB data, and only keeps entries that have an intersection
+        (or no geometry) with the supplied shape. Original geometries are preserved, so the data is clipped, not the
+        geometries
+
+        :param data: Data to be clipped
+        :param shape: (Multi)Polygon used for the clipping of the data
+        :return: Clipped data
+        """
+        for layer in data.keys():
+            self.logger.debug(f"Check if layer {layer} has geometry")
+            gdf = data[layer]
+            intersections = gdf[gdf.geometry.intersects(shape) | gdf.geometry.isnull()]
+            data[layer] = intersections
+        return data
+
+    def translate(self, data, translation_file):
+        """
+        Loads a translation file and translates the data datastructure.
+        Renames tables and columns as indicated in the translation_file
+
+        :param data: Data to be translated
+        :param translation_file: Path to translation file
+        :return: Translated data
+        """
+
+        # load file
+        f = open(translation_file)
+
+        try:
+            mapping = json.loads(json.dumps(json.load(f)).lower())
+        except json.decoder.JSONDecodeError:
+            self.logger.error("Structure of DAMO-translation file is incorrect, check brackets and commas")
+            raise
+
+        translate_layers = {}
+        for layer in data.keys():
+            # Check if the layer name is mapped in the translation file
+            for layer_name in mapping.keys():
+                if layer == layer_name:
+                    # Map column names
+                    self.logger.debug(f"Mapping column names of layer {layer}")
+                    data[layer].rename(columns=mapping[layer]['columns'], inplace=True)
+
+                    # Store layer mapping in dict to be mapped later
+                    translate_layers[layer_name] = mapping[layer]['name']
+
+        # Map layer names
+        for old, new in translate_layers.items():
+            data[new] = data.pop(old)
+
+        return data
+
+    def from_file(self, damo_filename, hdb_filename, translation_DAMO=None, translation_HDB=None, ):
+        """
+        Function that loads the data in GeoDataFrames and applies layer and column mapping
+
+        :param damo_filename: Path to the .gbd folder with DAMO data
+        :param hdb_filename: Path to the .gbd folder with HDB data
+        :param translation_DAMO: Path to the DAMO translation dictionary
+        :param translation_HDB: Path to the HDB translation dictionary
+        :return: Dictionary containing layer names (keys) and GeoDataFrames (values)
+        """
+
+        # Define empty data dictionary, to be filled with layer data from file
+        data = {}
+
+        # Load layers within .gdb datasets
+        self.logger.debug('Find layer names within geopackages')
+        layers_gdb_damo = fiona.listlayers(damo_filename)
+        layers_gdb_hdb = fiona.listlayers(hdb_filename)
+
+        # Start reading DAMO
+        for layer in layers_gdb_damo:
+            # Check if the layer name is mapped in the translation file
+            if layer in DAMO_LAYERS:
+                # Map column names
+                self.logger.debug(f"Reading DAMO layer {layer}")
+                gdf_damo = gpd.read_file(damo_filename, layer=layer)
+                gdf_damo.columns = gdf_damo.columns.str.lower()
+                data[layer.lower()] = gdf_damo
+
+        # Start reading HDB
+        for layer in layers_gdb_hdb:
+            # Check if the layer name is mapped in the translation file
+            if layer in HDB_LAYERS:
+                # Map column names
+                self.logger.debug(f"Reading HDB layer {layer}")
+                gdf_hdb = gpd.read_file(hdb_filename, layer=layer)
+                gdf_hdb.columns = gdf_hdb.columns.str.lower()
+                data[layer.lower()] = gdf_hdb
+
+        # Start translation DAMO
+        if translation_DAMO is not None:
+            self.logger.debug("Start mapping layer and column names of DAMO layers")
+            data = self.translate(data, translation_DAMO)
+
+        # Start translation DAMO
+        if translation_HDB is not None:
+            self.logger.debug("Start mapping layer and column names of DAMO layers")
+            data = self.translate(data, translation_HDB)
+
+        return data
+
+    def export_comparison(self, table_C, statistics, filename, overwrite=False, styling_path=None):
+        """
+        Exports all compared layers and statistics to a GeoPackage.
+
+        :param table_C: Dictionary containing a GeoDataframe per layer
+        :param statistics: Dataframe containing the statistics
+        :param filename: Filename of the GeoPackage to export to
+        :param overwrite: If true it will delete the old GeoPackage
+        :param styling_path: Path to folder containing .qml files. For each layer in table_C it will lookup a .qml file
+        with the exact same name as the layer
+        :return:
+        """
+
+        table = []
+        if Path(filename).exists():
+            if overwrite:
+                self.logger.debug("file exists, overwrite is used so delete old file")
+                try:
+                    Path.unlink(filename)
+                except PermissionError:
+                    self.logger.error(
+                        "File to export to is still in use. Unload GPKG from QGIS and disconnect database connections")
+            else:
+                raise FileExistsError(f'The file "{filename}" already exists. If you want to overwrite the '
+                                      f'existing file, add overwrite=True to the function.')
+
+        # Deal with multiple geometry types per layer. Split each layer in a LayerName_Point or LayerName_LineString
+        # and delete the original layer
+        for layer_name in list(table_C):
+            if len(table_C[layer_name].geometry.type.unique()) > 1:
+                for geometry_type in range(len(table_C[layer_name].geometry.type.unique())):
+                    table_C[f'{layer_name}_{table_C[layer_name].geometry.type.unique()[geometry_type]}'] = \
+                        table_C[layer_name][
+                            table_C[layer_name].geometry.type == table_C[layer_name].geometry.type.unique()[
+                                geometry_type]]
+                del table_C[layer_name]
+
+        # Add an entry to the styling table. First check if a qml file exists with the same name as the layer.
+        # If not, add the default styling for either point, linestring or polygon
+        for i, layer_name in enumerate(table_C):
+            # Check if the layer name has a style in the styling folder
+            if styling_path is not None:
+                qml_name = layer_name + ".qml"
+                qml_file = styling_path / qml_name
+
+                # if file exists, use that for the styling
+                if qml_file.exists():
+                    self.logger.debug(f"Style layer for layer {layer_name} found, adding it to the GeoPackage")
+                    with open(qml_file, "r") as file:
+                        style = file.read()
+                        style_name = layer_name + "_style"
+                        table.append(
+                            [i, None, None, layer_name, table_C[layer_name]._geometry_column_name, style_name,
+                             style, None, 'false', None, None, None, None])
+                else:
+                    if table_C[layer_name].geometry.type.unique() is None:
+                        pass
+                    if table_C[layer_name].geometry.type.drop_duplicates().to_list() == ['Point']:
+                        table.append(
+                            [i, None, None, layer_name, table_C[layer_name]._geometry_column_name, 'point_style',
+                             STYLING_POINTS_DAMO, None, 'false', None, None, None, None])
+                    if table_C[layer_name].geometry.type.drop_duplicates().to_list() == ['LineString'] or table_C[
+                        layer_name].geometry.type.drop_duplicates().to_list() == ['MultiLineString']:
+                        table.append(
+                            [i, None, None, layer_name, table_C[layer_name]._geometry_column_name, 'line_style',
+                             STYLING_LINES_DAMO, None, 'false', None, None, None, None])
+                    if table_C[layer_name].geometry.type.drop_duplicates().to_list() == ['Polygon'] or table_C[
+                        layer_name].geometry.type.drop_duplicates().to_list() == ['MultiPolygon']:
+                        table.append(
+                            [i, None, None, layer_name, table_C[layer_name]._geometry_column_name, 'polygon_style',
+                             STYLING_POLYGONS_DAMO, None, 'false', None, None, None, None])
+
+            self.logger.info(f"export results of comparing DAMO/DAMO layer {layer_name} to geopackage")
+            table_C[layer_name].to_file(filename, layer=layer_name, driver="GPKG")
+
+        # add styling to layers
+        layer_styles = gpd.GeoDataFrame(columns=STYLING_BASIC_TABLE_COLUMNS, data=table)
+        layer_styles.fillna("", inplace=True)
+        self.add_layer_styling(fn_export_gpkg=filename, layer_styles=layer_styles)
+
+        # Call function export statistics
+        self.export_statistics(statistics, filename)
+
+    def compare_with_damo(self, damo_b, attribute_comparison=None, filename=None, overwrite=False, styling_path=None):
+        """
+        Compare two DAMO objects with eachother, self (damo_a) and other (damo_b).
+        For every layer in the datasets (brug, duikersyfonhevel, etc.) an outer join based on the code will be made.
+        For every asset the presence in each dataset will be available
+
+        :param damo_b: DAMO object to compare with
+        :param filename: Path to export the results as a Geopackage
+        :param overwrite: Overwrite results
+        :return: Tables with all data assets and in which dataset it is present (A = only present in this object,
+        B = only present in the other object, AB = present in both objects). If asset is available in AB, but the
+        geometries differ, the geometry of A is exported.
+        Additionally, a table with statistics is returned
+        """
+
+        # copy damo data and add column with True values
+        self.logger.debug("create copies of tables")
+        table_A = self.data.copy()
+        table_B = damo_b.data.copy()
+
+        table_C = {}
+        for layer in table_A.keys():
+
+            if not table_B.keys().__contains__(layer):
+                self.logger.warning(f"Layer {layer} does not exist in the other dataset, skipping layer")
+                continue
+
+            self.logger.debug(f"Merging {layer} of A and B datasets")
+
+            # Reproject crs B to A if crs are different
+            if table_A[layer].crs == table_A[layer].crs:
+                self.logger.debug(f"CRS of layer {layer} is equal")
+            else:
+                table_B[layer].to_crs(crs=table_A[layer].crs)
+            crs = table_A[layer].crs
+
+            try:
+                # Add geometry information (length/area) to dataframe
+                self.logger.debug(f"Adding geometry to table_A[{layer}]")
+                table_A[layer] = self.add_geometry_info(table_A[layer])
+                self.logger.debug(f"Adding geometry to table_B[{layer}]")
+                table_B[layer] = self.add_geometry_info(table_B[layer])
+
+                # Add 'dataset' column, after merging this will become 'dataset_A' and 'dataset_B'
+                table_A[layer]['dataset'] = True
+                table_B[layer]['dataset'] = True
+
+                # Add layer of origin to dataset
+                table_A[layer]['origin'] = layer
+                table_B[layer]['origin'] = layer
+
+                # outer merge on the two tables with suffixes
+                table_A[layer] = table_A[layer].add_suffix('_A').rename(columns={'code_A': 'code'})
+                table_B[layer] = table_B[layer].add_suffix('_B').rename(columns={'code_B': 'code'})
+
+                #make sure the code column is of type string for proper merging
+                table_A[layer]['code'] = table_A[layer]['code'].astype('string')
+                table_B[layer]['code'] = table_B[layer]['code'].astype('string')
+
+                table_merged = table_A[layer].merge(table_B[layer], how="outer", on='code') #Futurewarning
+                table_merged['geometry'] = None
+                table_merged = gpd.GeoDataFrame(table_merged, geometry='geometry')
+
+                # fillna values of the two columns by False
+                table_merged[['dataset_A', 'dataset_B']] = table_merged[['dataset_A', 'dataset_B']].fillna(value=False)
+
+                # add column with values A, B or AB, depending on code
+                inboth = []
+                geometry_adjusted = []
+                for i in range(len(table_merged)):
+                    if table_merged['dataset_A'][i] & table_merged['dataset_B'][i]:
+                        inboth.append('AB')
+                        # geometry_adjusted.append(table_merged['geometry_A'][i] != table_merged['geometry_B'][i])
+                    elif table_merged['dataset_A'][i] and not table_merged['dataset_B'][i]:
+                        inboth.append('A')
+                        # geometry_adjusted.append(None)
+                    else:
+                        inboth.append('B')
+                        # geometry_adjusted.append(None)
+                table_merged['in_both'] = inboth
+                table_merged['geometry_adjusted'] = (table_merged['geometry_A'] != table_merged['geometry_B'])
+
+                # use geometry of A (new) when feature exists in A or in A and B, use geometry of B (old) when feature
+                # only exists in B
+                if layer in [x.lower() for x in GEOMETRICAL_COMPARISON_LAYERS]:
+                    if layer == 'waterdeel':
+                        # For waterdeel we cannot compare based on code. So we treat A and B as one big polygon and
+                        # determine the intersection and the differences
+                        union_A = table_merged.geometry_A.unary_union
+                        union_B = table_merged.geometry_B.unary_union
+                        intersection = union_A.intersection(union_B)
+                        diff_A = union_A.difference(union_B)
+                        diff_B = union_B.difference(union_A)
+
+                        df_intersections = gpd.GeoDataFrame(gpd.GeoSeries([intersection, diff_A, diff_B])) \
+                            .rename(columns={0: "geometry"}).set_geometry('geometry')
+                        df_intersections['in_both'] = pd.Series(['AB', 'A', 'B'])
+                        df_intersections = df_intersections.explode(column='geometry', index_parts=True)
+                        table_merged = df_intersections[df_intersections.geometry.geom_type == 'Polygon'].copy()
+
+                        table_merged.loc[table_merged['in_both'].isin(['A', 'AB']), 'geom_area_A'] = table_merged[
+                            'geometry'].area
+                        table_merged.loc[~table_merged['in_both'].isin(['A', 'AB']), 'geom_area_A'] = None
+
+                        table_merged.loc[table_merged['in_both'].isin(['B', 'AB']), 'geom_area_B'] = table_merged[
+                            'geometry'].area
+                        table_merged.loc[~table_merged['in_both'].isin(['B', 'AB']), 'geom_area_B'] = None
+
+                        table_merged['geom_length_A'] = 0
+                        table_merged['geom_length_B'] = 0
+                    else:
+                        # hier iets om geometrieen te bepalen
+                        intersection = gpd.GeoDataFrame(pd.concat([table_merged.code, table_merged['geometry_A']
+                                                                  .intersection(table_merged['geometry_B'])], axis=1)) \
+                            .rename(columns={0: "geometry_diff"})
+                        intersection['origin'] = 'intersection'
+                        diff_A = gpd.GeoDataFrame(pd.concat([table_merged.code, table_merged['geometry_A']
+                                                            .difference(table_merged['geometry_B'])], axis=1)) \
+                            .rename(columns={0: "geometry_diff"})
+                        diff_A['origin'] = 'diff_A'
+                        diff_B = gpd.GeoDataFrame(pd.concat([table_merged.code, table_merged['geometry_B'].
+                                                            difference(table_merged['geometry_A'])], axis=1)). \
+                            rename(columns={0: "geometry_diff"})
+                        diff_B['origin'] = 'diff_B'
+
+                        df_intersections = pd.concat([intersection, diff_A, diff_B])
+                        df_intersections = df_intersections[df_intersections['geometry_diff'].notna()]
+                        table_merged = table_merged.merge(df_intersections, how="outer", on='code')
+
+                        # table_merged = table_merged.explode(column='geometry_diff', index_parts=True)
+                        # table_merged = table_merged[table_merged.geometry_diff.geom_type == 'Polygon']
+
+                        table_merged['geometry_diff'] = table_merged.apply(
+                            lambda x: self.get_significant_geometry(x['in_both'], x['geometry_A'], x['geometry_B']) if (
+                                    x['geometry_diff'] is None) else x['geometry_diff'], axis=1)
+                        table_merged['origin'].fillna(table_merged['in_both'], inplace=True)
+                        table_merged['geometry'] = table_merged['geometry_diff']
+
+                        table_merged = table_merged.explode(column='geometry', index_parts=True)
+                        table_merged = table_merged[table_merged.geometry.geom_type == 'Polygon']
+
+                else:
+                    table_merged['geometry'] = table_merged.apply(
+                        lambda x: self.get_significant_geometry(x['in_both'], x['geometry_A'],
+                                                                x['geometry_B']), axis=1)
+                # remove all geometry columns except 'geometry'
+                table_merged = self.drop_unused_geoseries(table_merged, keep='geometry')
+                table_C[layer] = gpd.GeoDataFrame(table_merged, geometry='geometry', crs=crs)
+
+            except KeyError as err:
+                self.logger.warning(f"Column {err.args[0]} not found in layer {layer}, skipping layer")
+                continue
+
+        # Apply attribute comparison
+        if attribute_comparison is not None:
+            table_C = self.apply_attribute_comparison(attribute_comparison, table_C)
+            table_C = self.summarize_attribute_comparison(table_C)
+
+        # determine statistics: count amount of shapes per layer for dataset A and B
+        self.logger.debug("create statistics")
+        statistics = pd.DataFrame(
+            columns=['Count A', 'Count B', 'Count difference', 'Length A', 'Length B', 'Length difference', 'Area A',
+                     'Area B', 'Area difference'])
+        for i, layer_name in enumerate(table_C):
+            self.logger.debug(f"Layer name: {layer_name}")
+            count_A = len(table_C[layer_name].loc[(table_C[layer_name]['in_both'] == 'A') |
+                                                  (table_C[layer_name]['in_both'] == 'AB')])
+            count_B = len(table_C[layer_name].loc[(table_C[layer_name]['in_both'] == 'B') |
+                                                  (table_C[layer_name]['in_both'] == 'AB')])
+            count_diff = count_B - count_A
+            length_A = sum(table_C[layer_name].loc[(table_C[layer_name]['in_both'] == 'A') |
+                                                   (table_C[layer_name]['in_both'] == 'AB')].geom_length_A)
+            length_B = sum(table_C[layer_name].loc[(table_C[layer_name]['in_both'] == 'B') |
+                                                   (table_C[layer_name]['in_both'] == 'AB')].geom_length_B)
+            length_diff = length_B - length_A
+            area_A = sum(table_C[layer_name].loc[(table_C[layer_name]['in_both'] == 'A') |
+                                                 (table_C[layer_name]['in_both'] == 'AB')].geom_area_A)
+            area_B = sum(table_C[layer_name].loc[(table_C[layer_name]['in_both'] == 'B') |
+                                                 (table_C[layer_name]['in_both'] == 'AB')].geom_area_B)
+            area_diff = area_B - area_A
+            statistics.loc[layer_name, :] = [count_A, count_B, count_diff, length_A, length_B, length_diff, area_A,
+                                             area_B, area_diff]
+        statistics = statistics.fillna(0).astype('int64')
+
+        # check if filename already exists. Cr
+        if filename is not None:
+            self.export_comparison(table_C, statistics, filename, overwrite=overwrite, styling_path=styling_path)
+
+        return table_C, statistics

--- a/hhnk_threedi_tools/core/vergelijkingstool/Dataset.py
+++ b/hhnk_threedi_tools/core/vergelijkingstool/Dataset.py
@@ -1,0 +1,419 @@
+import geopandas as gpd
+import pandas as pd
+import sqlite3
+import json
+from shapely.geometry import LineString, Polygon
+import math
+
+from config import *
+
+class DataSet:
+    """
+    Parent class of DAMO and Threedimodel
+    """
+
+    def __init__(self):
+        """
+        Initialisation of a dataset.
+        """
+        # Set priority columns
+        self.data = None
+        self.priority_columns = {}
+
+    def add_layer_styling(self, fn_export_gpkg, layer_styles):
+        """
+        Adds and fills a helper table 'layer_styles' to the GeoPackage containing the style per layer.
+        When the GeoPackage is loaded into QGIS, the layers are auto-loaded
+
+        :param fn_export_gpkg: Filename of the GeoPackage to write to
+        :param layer_styles: Dataframe containing the QML styles for the different layers
+        :return: None
+        """
+        con = sqlite3.connect(fn_export_gpkg)
+        cur = con.cursor()
+
+        # drop layer_styles table if it already exists and create a new one
+        SQL_DROP_LAYER_STYLES = """DROP TABLE IF EXISTS layer_styles"""
+        SQL_CREATE_LAYER_STYLES = """CREATE TABLE "layer_styles" ("id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, "f_table_catalog" TEXT(256), "f_table_schema" TEXT(256), "f_table_name" TEXT(256), "f_geometry_column" TEXT(256), "styleName" TEXT(30), "styleQML" TEXT, "styleSLD" TEXT, "useAsDefault" BOOLEAN, "description" TEXT, "owner" TEXT(30), "ui" TEXT(30), "update_time" DATETIME DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')));"""
+        con.execute(SQL_DROP_LAYER_STYLES)
+        con.execute(SQL_CREATE_LAYER_STYLES)
+
+        # add layer_styles to gpkg
+        SQL_INSERT_GPKG_CONTENT = "INSERT INTO gpkg_contents (table_name, data_type) values ('layer_styles','attributes')"
+        con.execute(SQL_INSERT_GPKG_CONTENT)
+
+        # fill layer_styles
+        for row in layer_styles.itertuples():
+            data = {
+                "id": row.id,
+                "f_table_catalog": row.f_table_catalog,
+                "f_table_schema": row.f_table_schema,
+                "f_table_name": row.f_table_name,
+                "f_geometry_column": 'geom',
+                "styleName": row.styleName,
+                "styleQML": row.styleQML,
+                "useAsDefault": row.useAsDefault
+            }
+            con.execute(
+                'INSERT INTO layer_styles (id, f_table_catalog, f_table_schema, f_table_name, f_geometry_column, styleName, styleQML, useAsDefault) VALUES (:id, :f_table_catalog, :f_table_schema, :f_table_name, :f_geometry_column, :styleName, :styleQML, :useAsDefault)',
+                data)
+        con.commit()
+        cur.close()
+        con.close()
+
+    def get_significant_geometry(self, dataset, geometry_A, geometry_B):
+        """
+        Returns the significant geometry based on the origin of the geometry in the datasets.
+        If an asset occurs in dataset A (self) or in A AND B, geometry A is returned.
+        If an asset occurs ONLY in dataset B, geometry B is returned.
+
+        :param dataset: String indicating in which dataset the asset is found
+        :param geometry_A: Shapely geometry
+        :param geometry_B: Shapely geometry
+        :return: Shapely geometry
+        """
+        if dataset == 'A' or dataset == 'AB':
+            return geometry_A
+        else:
+            return geometry_B
+
+    def create_structure_geometry(self, point_start, point_end):
+        """
+        Creates a LineString from structures that are only defined by a start and end point.
+        If only a start point is supplied, the start point is returned
+
+        :param point_start: Shapely geometry of the start point
+        :param point_end: Shapely geometry of the end point
+        :return: Shapely Point or Linestring
+        """
+        if point_end is None:
+            output_geometry = point_start
+        else:
+            output_geometry = LineString([point_start, point_end])
+
+        return output_geometry
+
+    def add_geometry_info(self, gdf):
+        """
+        Adds columns regarding the geometry type, length and area as attributes to a GeoDatarame
+
+        :param gdf: GeoDataframe to be analyzed
+        :return: GeoDataframe with added columns
+        """
+        if 'geometry' in gdf.columns:
+            gdf["geom_type"] = gdf["geometry"].apply(lambda geom: geom.geom_type if geom is not None else None)
+            gdf["geom_length"] = gdf.geometry.length
+            gdf["geom_area"] = gdf.geometry.area
+        return gdf
+
+    def drop_unused_geoseries(self, gdf, keep='geometry'):
+        """
+        Removes all GeoSeries from a GeoDataframe except the column indicated with the 'keep' parameter.
+        Used because for the export to GeoPackage, a GeoDataframe is only allowed to have 1 geometry column
+
+        :param gdf: GeoDataframe to be stripped of unused GeoSeries
+        :param keep: Name of the geometry column to keep
+        :return: GeoDataframe stripped of unused GeoSeries
+        """
+        drop_columns = []
+        for column in gdf.columns:
+            if isinstance(gdf[column], gpd.geoseries.GeoSeries) and column != keep:
+                drop_columns.append(column)
+        gdf = gdf.drop(columns=drop_columns)
+        return gdf
+
+    def compare_function(self, table, function):
+        """
+        Apply a function with arguments on a table.
+        Function contains
+
+        :param table: GeoDataframe on which the function is applied
+        :param function: Dictionary containing the function and arguments
+        :return:
+        """
+        function_name = list(function.keys())[0]
+
+        def resolve_parameter(table, parameter):
+            """
+            Resolves the parameters of a function. If the parameter is a string, the column in the table with that header is returned.
+            If the parameter is a dict, a recursive function is applied.
+            If the parameter is a number, the value is used
+
+            :param table: GeoDataframe on which the function is applied
+            :param parameter: String, dict or number
+            :return:
+            """
+            if isinstance(parameter, str):
+                try:
+                    return table[parameter]
+                except KeyError:
+                    self.logger.error(f"Could not resolve comperation parameter {parameter}")
+                    return None
+            elif isinstance(parameter, dict):
+                compare, *_ = self.compare_function(table, parameter)
+                return compare
+            elif isinstance(parameter, int) or isinstance(parameter, float):
+                return parameter
+            else:
+                self.logger.error(f"Could not resolve comperation parameter {parameter}")
+                return None
+
+        try:
+            param_left = function[function_name]['left']
+            param_right = function[function_name]['right']
+            left = resolve_parameter(table, param_left)
+            right = resolve_parameter(table, param_right)
+
+            try:
+                skipna = function[function_name]['skipna']
+                self.logger.debug(f"Adding skipna to function within function {function_name}")
+            except:
+                skipna = False
+
+            # check if there was a change from NaN to a number, or from a number to NaN
+            if isinstance(left, pd.Series) and isinstance(right, pd.Series):
+                change_na = (left.isna() & right.notna()) | (left.notna() & right.isna())
+            else:
+                change_na = None
+
+            # try:
+            #    change_na = (left.isna() & right.notna()) | (left.notna() & right.isna())
+            # except:
+            #    change_na = None
+
+            ### DIFFERENCE ###
+            if function_name == "difference":
+                result = left - right
+            ### ADD ###
+            elif function_name == "add":
+                result = left + right
+            ### MINIMUM
+            elif function_name == "minimum":
+                result = pd.concat([left, right], axis=1).min(axis=1, skipna=skipna)
+            ### MAXIMUM
+            elif function_name == "maximum":
+                result = pd.concat([left, right], axis=1).max(axis=1, skipna=skipna)
+            elif function_name == "multiply":
+                result = left * right
+
+            else:
+                self.logger.error(f"Comparison function {function_name} not recognized")
+                result = None
+
+            return result, change_na
+
+        except TypeError:
+            self.logger.error(f"TypeError: Unable to calculate {function_name} on {param_left} and {param_right}")
+            return None, None
+
+        except AttributeError as err:
+            self.logger.error(
+                f"AttributeError: Unable to calculate {function_name} on {param_left} and {param_right}. One of the parameters might not be available in the data. Skipping comparison")
+            return None, None
+
+    def compare_category(self, row, priority):
+        """
+        Compares two values in a row on category. Returns a value only if the asset occurs in A and B (or DAMO and Model)
+        Returns not changed if there is no change in the category
+
+        :param row: row containing the left and right column to be compared and the 'in_both' column.
+        :return: String containing the change in category, if any.
+        """
+
+        if row.in_both == 'AB' or row.in_both == 'both':
+            left = row[0]
+            right = row[1]
+
+            if isinstance(left, float):
+                if left.is_integer():
+                    left = str(int(left))
+            if isinstance(right, float):
+                if right.is_integer():
+                    right = str(int(right))
+
+            if left != right:
+                # if left and right are nan, don't fill anything, else fill "left -> right"
+                if str(left) == 'nan' and str(right) == 'nan':
+                    return (None, None)
+                else:
+                    return ((str(left) + ' -> ' + str(right)), priority)
+            else:
+                # if left and right the same and not nan
+                if isinstance(left, float):
+                    if ~math.isnan(left):
+                        return ('not changed', None)
+                else:
+                    return ('not changed', None)
+        return (None, None)
+
+    def compare_attribute(self, df, comparison):
+        """
+        For a comparison, determine the type and resolve the function. Creates a new column with the result of the comparison
+
+        :param df: (Geo)Dataframe on which a comparison is applied
+        :param comparison: Dictionary with the comparison rules
+        :return:
+        """
+
+        self.logger.debug(f"Applying comparison with the following data: {comparison}")
+
+        name = comparison["name"]
+        self.logger.debug(f"Start comparison: {name}")
+        comparison_type = comparison["type"]
+        table_name = comparison["table"]
+        table = df[table_name]
+
+        # Try reading the priority, if not set, use "critical"
+        try:
+            priority = comparison["priority"]
+        except KeyError:
+            self.logger.info(f"No priority set for comparison {name}, setting it to \"critical\"")
+            priority = "critical"
+
+        if comparison_type == "numeric":
+            function = comparison["function"]
+            self.logger.debug(f"Comparison type: numeric")
+
+            # Try to read the numerical threshold, if not set, use default value
+            try:
+                threshold = comparison["threshold"]
+            except KeyError:
+                self.logger.info(
+                    f"No numeric threshold set for comparison {name}, using default value of {COMPARISON_GENERAL_THRESHOLD}")
+                threshold = COMPARISON_GENERAL_THRESHOLD
+
+            # add new column with the comparison name, and result from the compare function
+            try:
+                column_name_nan_change = name + "_change_NaN"
+                column_name_priority = name + "_priority"
+                compare_result, compare_nan_change = self.compare_function(table, function)
+
+                # apply threshold
+                try:
+                    compare_result[abs(compare_result) < threshold] = 0
+                except TypeError:
+                    self.logger.debug(f"Unable to apply threshold on comparison {name}")
+
+                # store in dataframe
+                if isinstance(compare_result, pd.Series):
+                    df[table_name][name] = compare_result
+                    df[table_name][column_name_nan_change] = compare_nan_change
+                    df[table_name][column_name_priority] = pd.Series(
+                        [priority if x else '' for x in abs(compare_result) > 0])
+
+                    # Add column_name_priority to the priority_columns dict
+                    if table_name not in self.priority_columns.keys():
+                        self.priority_columns[table_name] = []
+
+                    self.priority_columns[table_name].append(column_name_priority)
+                else:
+                    self.logger.warning(f"Comparison {name} had None as result")
+
+            except TypeError:
+                self.logger.error(f"Unable to apply comparation {name}, skipping")
+                # raise
+
+        elif comparison_type == "category":
+            self.logger.debug(f"Comparison type: category")
+            left = comparison["left"]
+            right = comparison["right"]
+
+
+            column_name_priority = name + "_priority"
+            if table_name not in self.priority_columns.keys():
+                self.priority_columns[table_name] = []
+
+            self.priority_columns[table_name].append(column_name_priority)
+
+            df[table_name][[name, column_name_priority]] = df[table_name][[left, right, 'in_both']].apply(
+                lambda row: self.compare_category(row, priority), axis=1, result_type='expand')
+        else:
+            self.logger.debug(f"Comparison type {comparison_type} not implemented")
+        return df
+
+    def summarize_attribute_comparison(self, table):
+        """
+        Analyzes the priority columns in the compared table and summarizes per row how many critical, warning, and
+        info's ar counted
+        :param table: Dictionary containing all the comparison tables
+        :return: Dictionary containing all the comparison tables including the summary columns
+        """
+
+        # create lambda function
+        count_occurrences = lambda row, string: row.tolist().count(string)
+        for layer in self.priority_columns.keys():
+            # If there is a priority_column
+            if layer:
+                columns = self.priority_columns[layer]
+                table[layer]['number_of_info'] = table[layer][columns].apply(lambda row: count_occurrences(row, 'info'),
+                                                                             axis=1)
+                table[layer]['number_of_warning'] = table[layer][columns].apply(
+                    lambda row: count_occurrences(row, 'warning'), axis=1)
+                table[layer]['number_of_critical'] = table[layer][columns].apply(
+                    lambda row: count_occurrences(row, 'critical'), axis=1)
+        return table
+
+    def apply_attribute_comparison(self, attribute_comparison, table):
+        """
+        Loads a attribute comparison json file and applies the comparison rules in the json on the supplied table
+
+        :param attribute_comparison: Path to file containing comparison rules
+        :param table: Table to apply the comparison rules on
+        :return:
+        """
+
+        self.logger.debug(f"Start applying attribute comparison")
+        try:
+            with open(attribute_comparison) as file:
+                att_comp = json.load(file)
+                for comparison in att_comp["comparisons"]:
+                    table = self.compare_attribute(table, comparison)
+
+
+        except json.decoder.JSONDecodeError as err:
+            self.logger.error(
+                f"Unable to load attribute comparison file. JSON structure incorrect. {err.args[0]}. Skipping attribute comparison")
+        except FileNotFoundError as err:
+            self.logger.error(
+                f"Unable to load attribute comparison file. File {err.filename} does not exist. Skipping attribute comparison")
+        return table
+
+    def get_structure_by_code(self, code_start: str, layers):
+        """
+        Searches in all layers for entries based on code.
+        If a rows 'code' column starts with code_start, it is appended to the return table,
+        keeping all columns from different sources.
+        Example, when searching for 'KDU' it returns all assets (in this case 'Duikers'),
+        both from the v2_orifice as the v2_culvert layer
+
+        :param code_start: Start of code to search for
+        :return: DataFrame containing all found entries
+        """
+        tabel = pd.DataFrame()
+        for layer in layers:
+            codes = []
+            for i in self.data[layer].code.values:
+                if i is not None:
+                    i = str(i)
+                    if i.startswith(code_start):
+                        codes.append(i)
+            if codes:
+                layer_data = self.data[layer][self.data[layer]['code'].isin(codes)].copy()
+                layer_data['origin'] = layer
+                tabel = pd.concat((tabel, layer_data))
+
+        return tabel
+
+    def export_statistics(self, statistics, filename):
+        """
+        Export an attribute-only table to the GeoPackage
+
+        :param statistics: Dataframe containing statistics
+        :param filename: GeoPackage filename to export to
+        :return: None
+        """
+
+        self.logger.info(f"Exporting statistics to {filename}")
+        # For export to GeoPackage a geometry column is needed, fill it with None to create attribute only layer
+        statistics["geometry"] = None
+        gpd.GeoDataFrame(statistics, geometry='geometry').to_file(filename, layer='statistics', driver="GPKG")

--- a/hhnk_threedi_tools/core/vergelijkingstool/Dataset.py
+++ b/hhnk_threedi_tools/core/vergelijkingstool/Dataset.py
@@ -1,11 +1,13 @@
+import json
+import math
+import sqlite3
+
 import geopandas as gpd
 import pandas as pd
-import sqlite3
-import json
 from shapely.geometry import LineString, Polygon
-import math
 
-from config import *
+from hhnk_threedi_tools.core.vergelijkingstool.config import *
+
 
 class DataSet:
     """
@@ -39,7 +41,9 @@ class DataSet:
         con.execute(SQL_CREATE_LAYER_STYLES)
 
         # add layer_styles to gpkg
-        SQL_INSERT_GPKG_CONTENT = "INSERT INTO gpkg_contents (table_name, data_type) values ('layer_styles','attributes')"
+        SQL_INSERT_GPKG_CONTENT = (
+            "INSERT INTO gpkg_contents (table_name, data_type) values ('layer_styles','attributes')"
+        )
         con.execute(SQL_INSERT_GPKG_CONTENT)
 
         # fill layer_styles
@@ -49,14 +53,15 @@ class DataSet:
                 "f_table_catalog": row.f_table_catalog,
                 "f_table_schema": row.f_table_schema,
                 "f_table_name": row.f_table_name,
-                "f_geometry_column": 'geom',
+                "f_geometry_column": "geom",
                 "styleName": row.styleName,
                 "styleQML": row.styleQML,
-                "useAsDefault": row.useAsDefault
+                "useAsDefault": row.useAsDefault,
             }
             con.execute(
-                'INSERT INTO layer_styles (id, f_table_catalog, f_table_schema, f_table_name, f_geometry_column, styleName, styleQML, useAsDefault) VALUES (:id, :f_table_catalog, :f_table_schema, :f_table_name, :f_geometry_column, :styleName, :styleQML, :useAsDefault)',
-                data)
+                "INSERT INTO layer_styles (id, f_table_catalog, f_table_schema, f_table_name, f_geometry_column, styleName, styleQML, useAsDefault) VALUES (:id, :f_table_catalog, :f_table_schema, :f_table_name, :f_geometry_column, :styleName, :styleQML, :useAsDefault)",
+                data,
+            )
         con.commit()
         cur.close()
         con.close()
@@ -72,7 +77,7 @@ class DataSet:
         :param geometry_B: Shapely geometry
         :return: Shapely geometry
         """
-        if dataset == 'A' or dataset == 'AB':
+        if dataset == "A" or dataset == "AB":
             return geometry_A
         else:
             return geometry_B
@@ -100,13 +105,13 @@ class DataSet:
         :param gdf: GeoDataframe to be analyzed
         :return: GeoDataframe with added columns
         """
-        if 'geometry' in gdf.columns:
+        if "geometry" in gdf.columns:
             gdf["geom_type"] = gdf["geometry"].apply(lambda geom: geom.geom_type if geom is not None else None)
             gdf["geom_length"] = gdf.geometry.length
             gdf["geom_area"] = gdf.geometry.area
         return gdf
 
-    def drop_unused_geoseries(self, gdf, keep='geometry'):
+    def drop_unused_geoseries(self, gdf, keep="geometry"):
         """
         Removes all GeoSeries from a GeoDataframe except the column indicated with the 'keep' parameter.
         Used because for the export to GeoPackage, a GeoDataframe is only allowed to have 1 geometry column
@@ -159,13 +164,13 @@ class DataSet:
                 return None
 
         try:
-            param_left = function[function_name]['left']
-            param_right = function[function_name]['right']
+            param_left = function[function_name]["left"]
+            param_right = function[function_name]["right"]
             left = resolve_parameter(table, param_left)
             right = resolve_parameter(table, param_right)
 
             try:
-                skipna = function[function_name]['skipna']
+                skipna = function[function_name]["skipna"]
                 self.logger.debug(f"Adding skipna to function within function {function_name}")
             except:
                 skipna = False
@@ -208,7 +213,8 @@ class DataSet:
 
         except AttributeError as err:
             self.logger.error(
-                f"AttributeError: Unable to calculate {function_name} on {param_left} and {param_right}. One of the parameters might not be available in the data. Skipping comparison")
+                f"AttributeError: Unable to calculate {function_name} on {param_left} and {param_right}. One of the parameters might not be available in the data. Skipping comparison"
+            )
             return None, None
 
     def compare_category(self, row, priority):
@@ -220,7 +226,7 @@ class DataSet:
         :return: String containing the change in category, if any.
         """
 
-        if row.in_both == 'AB' or row.in_both == 'both':
+        if row.in_both == "AB" or row.in_both == "both":
             left = row[0]
             right = row[1]
 
@@ -233,17 +239,17 @@ class DataSet:
 
             if left != right:
                 # if left and right are nan, don't fill anything, else fill "left -> right"
-                if str(left) == 'nan' and str(right) == 'nan':
+                if str(left) == "nan" and str(right) == "nan":
                     return (None, None)
                 else:
-                    return ((str(left) + ' -> ' + str(right)), priority)
+                    return ((str(left) + " -> " + str(right)), priority)
             else:
                 # if left and right the same and not nan
                 if isinstance(left, float):
                     if ~math.isnan(left):
-                        return ('not changed', None)
+                        return ("not changed", None)
                 else:
-                    return ('not changed', None)
+                    return ("not changed", None)
         return (None, None)
 
     def compare_attribute(self, df, comparison):
@@ -267,7 +273,7 @@ class DataSet:
         try:
             priority = comparison["priority"]
         except KeyError:
-            self.logger.info(f"No priority set for comparison {name}, setting it to \"critical\"")
+            self.logger.info(f'No priority set for comparison {name}, setting it to "critical"')
             priority = "critical"
 
         if comparison_type == "numeric":
@@ -279,7 +285,8 @@ class DataSet:
                 threshold = comparison["threshold"]
             except KeyError:
                 self.logger.info(
-                    f"No numeric threshold set for comparison {name}, using default value of {COMPARISON_GENERAL_THRESHOLD}")
+                    f"No numeric threshold set for comparison {name}, using default value of {COMPARISON_GENERAL_THRESHOLD}"
+                )
                 threshold = COMPARISON_GENERAL_THRESHOLD
 
             # add new column with the comparison name, and result from the compare function
@@ -299,7 +306,8 @@ class DataSet:
                     df[table_name][name] = compare_result
                     df[table_name][column_name_nan_change] = compare_nan_change
                     df[table_name][column_name_priority] = pd.Series(
-                        [priority if x else '' for x in abs(compare_result) > 0])
+                        [priority if x else "" for x in abs(compare_result) > 0]
+                    )
 
                     # Add column_name_priority to the priority_columns dict
                     if table_name not in self.priority_columns.keys():
@@ -318,15 +326,15 @@ class DataSet:
             left = comparison["left"]
             right = comparison["right"]
 
-
             column_name_priority = name + "_priority"
             if table_name not in self.priority_columns.keys():
                 self.priority_columns[table_name] = []
 
             self.priority_columns[table_name].append(column_name_priority)
 
-            df[table_name][[name, column_name_priority]] = df[table_name][[left, right, 'in_both']].apply(
-                lambda row: self.compare_category(row, priority), axis=1, result_type='expand')
+            df[table_name][[name, column_name_priority]] = df[table_name][[left, right, "in_both"]].apply(
+                lambda row: self.compare_category(row, priority), axis=1, result_type="expand"
+            )
         else:
             self.logger.debug(f"Comparison type {comparison_type} not implemented")
         return df
@@ -345,12 +353,15 @@ class DataSet:
             # If there is a priority_column
             if layer:
                 columns = self.priority_columns[layer]
-                table[layer]['number_of_info'] = table[layer][columns].apply(lambda row: count_occurrences(row, 'info'),
-                                                                             axis=1)
-                table[layer]['number_of_warning'] = table[layer][columns].apply(
-                    lambda row: count_occurrences(row, 'warning'), axis=1)
-                table[layer]['number_of_critical'] = table[layer][columns].apply(
-                    lambda row: count_occurrences(row, 'critical'), axis=1)
+                table[layer]["number_of_info"] = table[layer][columns].apply(
+                    lambda row: count_occurrences(row, "info"), axis=1
+                )
+                table[layer]["number_of_warning"] = table[layer][columns].apply(
+                    lambda row: count_occurrences(row, "warning"), axis=1
+                )
+                table[layer]["number_of_critical"] = table[layer][columns].apply(
+                    lambda row: count_occurrences(row, "critical"), axis=1
+                )
         return table
 
     def apply_attribute_comparison(self, attribute_comparison, table):
@@ -369,13 +380,14 @@ class DataSet:
                 for comparison in att_comp["comparisons"]:
                     table = self.compare_attribute(table, comparison)
 
-
         except json.decoder.JSONDecodeError as err:
             self.logger.error(
-                f"Unable to load attribute comparison file. JSON structure incorrect. {err.args[0]}. Skipping attribute comparison")
+                f"Unable to load attribute comparison file. JSON structure incorrect. {err.args[0]}. Skipping attribute comparison"
+            )
         except FileNotFoundError as err:
             self.logger.error(
-                f"Unable to load attribute comparison file. File {err.filename} does not exist. Skipping attribute comparison")
+                f"Unable to load attribute comparison file. File {err.filename} does not exist. Skipping attribute comparison"
+            )
         return table
 
     def get_structure_by_code(self, code_start: str, layers):
@@ -398,8 +410,8 @@ class DataSet:
                     if i.startswith(code_start):
                         codes.append(i)
             if codes:
-                layer_data = self.data[layer][self.data[layer]['code'].isin(codes)].copy()
-                layer_data['origin'] = layer
+                layer_data = self.data[layer][self.data[layer]["code"].isin(codes)].copy()
+                layer_data["origin"] = layer
                 tabel = pd.concat((tabel, layer_data))
 
         return tabel
@@ -416,4 +428,4 @@ class DataSet:
         self.logger.info(f"Exporting statistics to {filename}")
         # For export to GeoPackage a geometry column is needed, fill it with None to create attribute only layer
         statistics["geometry"] = None
-        gpd.GeoDataFrame(statistics, geometry='geometry').to_file(filename, layer='statistics', driver="GPKG")
+        gpd.GeoDataFrame(statistics, geometry="geometry").to_file(filename, layer="statistics", driver="GPKG")

--- a/hhnk_threedi_tools/core/vergelijkingstool/README.md
+++ b/hhnk_threedi_tools/core/vergelijkingstool/README.md
@@ -1,0 +1,43 @@
+# 1Achtergrond
+
+Het Hoogheemraadschap Hollands Noorderkwartier (HHNK) heeft binnen het programma Bescherming Wateroverlast Noorderkwartier (BWN) een groot aantal poldermodellen opgebouwd. De basismodellen worden grotendeels automatisch opgebouwd uit beheergegevens. Na de opbouw van de basismodellen worden deze nog door hydrologen verder verbeterd en uitvoerig getest voordat de modellen ingezet worden voor de verschillende studies.
+
+Door wijzigingen in het watersysteem zijn de modellen na verloop van tijd niet meer helemaal actueel. Denk hierbij aan gebiedsontwikkeling en aanpassingen van kunstwerken, peilgebieden en profielen. Na verloop van tijd is het belangrijk de modellen te updaten naar deze nieuwe werkelijkheid. Hoewel het updaten van modellen voor een groot deel geautomatiseerd is, blijft het noodzakelijk dat een modelleur deze modellen goed analyseert en waar nodig verbetert. Omdat hier de nodige tijd bij komt kijken is het belangrijk om het moment waarop een model wordt geüpdatet goed te kiezen. Te vroeg en een model wordt voor niets opnieuw opgebouwd, te laat en er worden studies uitgevoerd met een verouderd model.
+
+Om verschillen tussen het model en de huidige situatie inzichtelijk te maken is de 'vergelijkingstool' ontwikkeld.
+
+# 2Beschrijving
+
+De vergelijkingstool heeft twee hoofdfuncties:
+
+- Brondata/Brondata-vergelijking. De 3Di modellen zijn automatisch opgebouwd uit brondata. De gebruikte brondata is door HHNK opgeslagen samen met de modellen. Door de gebruikte brondata (DAMO en HDB) te vergelijken met recente brondata krijgt men inzicht in de wijzigingen in de buitenruimte.
+- Model/Brondata-vergelijking. Soms zijn modellen handmatig nog geüpdatet of verbeterd, of zijn er andere aanpassingen gedaan. Door het model met brondata te vergelijking komen deze verschillen aan het licht.
+
+De vergelijkingen die worden uitgevoerd zijn uit te splitsen in twee categorieën:
+
+- Vergelijking op code.
+  - Voor de vergelijking brondata/brondata worden in beide datasets de lagen met dezelfde naam met elkaar vergeleken. Binnen deze laag wordt gekeken naar de "code" kolom om de data van beide datasets aan elkaar te koppelen. Per aanwezige code wordt aangegeven of deze alleen in dataset A, B of in beide (AB) voorkomt.
+  - Voor de vergelijking van model met brondata wordt gekeken naar de kunstwerken. Omdat deze in de modellen niet strikt gescheiden zijn per laag (duikers worden soms als culvert en soms als orifice geschematiseerd) worden alle lagen met kunstwerken beschouwd, en worden de kunstwerken gegroepeerd op kunstwerkcode. Zo worden alle kunstwerken die beginnen met 'KDU' vergeleken in de uitvoerlaag 'KDU'. Hetzelfde gebeurt met de andere type kunstwerken. Per kunstwerkcode wordt aangegeven of deze zich alleen in DAMO, alleen in het model of in beide bevindt.
+- Vergelijking op attribuut
+  - Door middel van configuratiebestanden kunnen attribuutvergelijkingen worden opgesteld. Dit zijn regels die verschillende kolommen in de data met elkaar vergelijken. Complexere numerieke vergelijkingen kunnen ook worden opgebouwd (verschil/som/minimum/maximum/vermenigvuldiging/deling van kolommen of waardes).
+  - Per attribuutvergelijking wordt een kolom toegevoegd met de uitkomst van de vergelijking en een kolom met de prioriteit van de opgegeven attribuutvergelijking ("critical", "warning", "info")
+  - Bij numerieke vergelijkingen wordt ook een kolom toegevoegd of de waardes in 1 van de twee datasets niet-ingevulde velden betreft.
+
+# 3Invoer
+
+- Brondata:
+  - DAMO FileGeoDatabase
+  - Hydrologen-database (HDB)
+- Model:
+  - 3Di modelschematisatie (sqlite)
+- Vertaalbestanden
+  - JSON-bestand(en) met vertaalregels om tabellen en kolommen ter hernoemen bij de import
+- Attribuutvergelijkingen
+  - JSON-bestand(en) met verschillende attribuutvergelijkingsregels
+- Styling-bestanden in styling map
+  - QML-bestanden met de styling voor de export naar GeoPackage. Een standaard-styling wordt aangenomen, maar als er een QML-bestand in de styling map wordt gevonden met dezelfde naamgeving als de naam van een export-laag, dan wordt deze styling aangenomen.
+
+# 4Uitvoer
+
+- Een GeoPackage met de resultaten van de brondata/brondata vergelijking, met alle lagen die in beide datasets aanwezig waren. Per laag statistieken over aantal, lengte of oppervlak van objecten in beide datasets.
+- Een GeoPackage met de resultaten van de model/brondata vergelijking, uitgesplitst naar kunstwerktypes. Per laag statistieken over aantal, lengte of oppervlak van objecten in beide datasets.

--- a/hhnk_threedi_tools/core/vergelijkingstool/Threedimodel.py
+++ b/hhnk_threedi_tools/core/vergelijkingstool/Threedimodel.py
@@ -1,0 +1,387 @@
+# importing external dependencies
+import numpy as np
+import logging
+import geopandas as gpd
+import pandas as pd
+import sqlite3
+import json
+from pathlib import Path
+
+from datamodels.Dataset import DataSet
+from config import *
+from styling import *
+
+# from pd.errors import DatabaseError #FIXME vanaf pd 1.5.3 beschikbaar. Als qgis zover is overzetten.
+from sqlite3 import DatabaseError
+
+
+class Threedimodel(DataSet):
+
+    def __init__(self, filename, translation=None):
+        """
+        Creates a Threedimodel object and reads the data from the 3Di schematisation sqlite.
+        If translation dictionaries are supplied, layer and column names are mapped.
+
+        :param filename: Path of the .sqlite file to be loaded
+        :param translation: Path of the translation dictionary to be used
+        """
+
+        self.logger = logging.getLogger('Threedimodel')
+        self.logger.debug('Created Threedimodel object')
+        self.data = self.from_sqlite(filename, translation)
+        self.join_cross_section_definition()
+
+        # Set priority columns
+        self.priority_columns = {}
+
+        for key in self.data.keys():
+            self.__setattr__(key, self.data[key])
+
+    def join_cross_section_definition(self):
+        """
+        Method to join the v2_cross_section_definition with the layers in self.data.
+        From the tabulated height and width, the maximum value is determined and added to the self.data layer.
+
+        :return: None
+        """
+
+        def max_value_from_tabulated(tabulated_string):
+            """
+            Determines the maximum value in a tabultated string
+            :param tabulated_string:
+            :return: Maximum value in a tabulated string
+            """
+            if tabulated_string is not None:
+                tabulated_array = np.fromstring(tabulated_string, dtype=float, sep=' ')
+                return np.max(tabulated_array)
+            else:
+                return None
+
+        cross_section_definition = self.data['v2_cross_section_definition'].set_index('id')
+        cross_section_definition['cross_section_max_width'] = cross_section_definition['width'].apply(
+            max_value_from_tabulated)
+        cross_section_definition['cross_section_max_height'] = cross_section_definition['height'].apply(
+            max_value_from_tabulated)
+
+        for layer in self.data:
+            if 'cross_section_definition_id' in list(self.data[layer].keys()):
+                self.data[layer] = self.data[layer].merge(
+                    cross_section_definition[['cross_section_max_width', 'cross_section_max_height']],
+                    how='left', left_on='cross_section_definition_id', right_on='id')
+
+    def add_geometry_from_connection_nodes(self, layer_data, data_connection_nodes):
+        """
+        Add a geometry column to a layer based on the start/end connection nodes. Used for example for v2_orifice,
+        as orifices are defined by the start/end connection nodes instead of by a geometry.
+
+        :param layer_data: GeoDataframe of layer to have a geometry added
+        :param data_connection_nodes: GeoDataframe containing the connection nodes
+        :return: GeoDataframe with appended geometry
+        """
+
+        layer_data['geometry'] = None
+        subset_data_connection_nodes = data_connection_nodes[['id', 'geometry']]
+        layer_data = layer_data.merge(subset_data_connection_nodes.fillna(-9999), how='left',
+                                      left_on='connection_node_start_id', right_on='id',
+                                      suffixes=(None, '_start'))
+        layer_data = layer_data.merge(subset_data_connection_nodes.fillna(-9999), how='left',
+                                      left_on='connection_node_end_id', right_on='id',
+                                      suffixes=(None, '_end'))
+        layer_data['geometry'] = layer_data.apply(
+            lambda x: self.create_structure_geometry(x['geometry_start'], x['geometry_end']), axis=1)
+        layer_data.drop(['geometry_start', 'geometry_end'], axis=1, inplace=True)
+        # result = gpd.GeoDataFrame(layer_data, geometry='geom')
+
+        return layer_data
+
+    def from_sqlite(self, filename, translation=None):
+        """
+        Load data from 3Di .sqlite file
+
+        :param filename: Path of the .sqlite file
+        :param translation: Path of the translation file
+        :return: Dictionary containing layer names (keys) and GeoDataFrames (values)
+        """
+
+        # Define empty data dictionary, to be filled with layer data from .sqlite
+        data = {}
+
+        self.logger.debug('called from_sqlite')
+
+        # Create connection with database
+        con = sqlite3.connect(filename)
+        cur = con.cursor()
+
+        # Load spatiallite extension. Make sure mod_spatialite.dll is in the System32 folder, see module description
+        # for installation instructions
+        self.logger.debug("Try loading mod_spatialite")
+        con.enable_load_extension(True)
+        cur.execute('SELECT load_extension("mod_spatialite")')
+
+        # Get overview of layers
+        res = con.execute(f"SELECT name FROM sqlite_schema WHERE type = 'table' AND name NOT LIKE 'sqlite_%';")
+        db_layers = res.fetchall()
+        if db_layers:
+            self.logger.debug(f"Layers results: {db_layers}")
+        else:
+            self.logger.error("No layers found in .sqlite, or file does not exist")
+            raise Exception("Error reading 3Di .sqlite")
+
+        # Loop over all layers starting with v2_ and put them in the data object
+        for layer in SQLITE_LAYERS:
+            self.logger.debug(f"Loading layer {layer}")
+
+            # Catch database error in case the table does not contain a geometry
+            try:
+                layer_data = pd.read_sql(f"SELECT *, ST_AsText(the_geom) as wkt_geom FROM {layer};", con)
+                gdf_layer_data = gpd.GeoDataFrame(layer_data,
+                                                  geometry=gpd.geoseries.from_wkt(layer_data["wkt_geom"].to_list()))
+                # layer_data['geom'] = gpd.geoseries.from_wkt(layer_data["wkt_geom"])
+            except:
+                self.logger.debug(f"Layer {layer} does not contain a geometry layer, loading as a table")
+                layer_data = pd.read_sql(f"SELECT * FROM {layer};", con)
+                try:
+                    # Try to create a geometry using the connection nodes
+                    layer_data = self.add_geometry_from_connection_nodes(layer_data, data['v2_connection_nodes'])
+                except KeyError:
+                    # Add without a geometry
+                    self.logger.debug(
+                        f"Layer {layer} does not have a geometry or reference to connection nodes. Import as normal "
+                        f"table")
+                gdf_layer_data = gpd.GeoDataFrame(layer_data)
+
+            # Add layer data to data object
+            data[layer] = gdf_layer_data
+        self.logger.debug('Done loading layers')
+
+        # Start translation
+        if translation is not None:
+            self.logger.debug("Start mapping layer and column names")
+            # load file
+            f = open(translation)
+
+            try:
+                mapping = json.loads(json.dumps(json.load(f)).lower())
+            except json.decoder.JSONDecodeError:
+                self.logger.error("Structure of translation file is incorrect")
+                raise
+
+            translate_layers = {}
+            for layer in data.keys():
+                # Check if the layer name is mapped in the translation file
+                for layer_name in mapping.keys():
+                    if layer == layer_name:
+                        # Map column names
+                        self.logger.debug(f"Mapping column names of layer {layer}")
+                        data[layer].rename(columns=mapping[layer]['columns'], inplace=True)
+
+                        # Store layer mapping in dict to be mapped later
+                        translate_layers[layer_name] = mapping[layer]['name']
+
+            # Map layer names
+            for old, new in translate_layers.items():
+                data[new] = data.pop(old)
+
+        self.logger.debug('Done loading .sqlite')
+        return data
+
+    def determine_statistics(self, table_C):
+        """
+        Per layer aggregate statistics like amount of entries, total length or total area for a layer,
+        and compare these model statistics with DAMO statistics.
+
+        :param table_C: Dict with GeoDataFrames containing the compared data
+        :return: DataFrame containing statistics
+        """
+
+        statistics = pd.DataFrame(
+            columns=['Count DAMO', 'Count 3Di', 'Count difference', 'Length DAMO', 'Length 3Di', 'Length difference',
+                     'Area DAMO', 'Area 3Di', 'Area difference'])
+        for i, layer_name in enumerate(table_C):
+            count_model = len(table_C[layer_name].loc[(table_C[layer_name]['in_both'] == 'model') |
+                                                      (table_C[layer_name]['in_both'] == 'both')])
+            count_DAMO = len(table_C[layer_name].loc[(table_C[layer_name]['in_both'] == 'damo') |
+                                                     (table_C[layer_name]['in_both'] == 'both')])
+            count_diff = count_model - count_DAMO
+
+            length_model = sum(table_C[layer_name].loc[(table_C[layer_name]['in_both'] == 'model') |
+                                                       (table_C[layer_name]['in_both'] == 'both')].geom_length_model)
+            length_DAMO = sum(table_C[layer_name].loc[(table_C[layer_name]['in_both'] == 'damo') |
+                                                      (table_C[layer_name]['in_both'] == 'both')].geom_length_damo)
+            length_diff = length_model - length_DAMO
+
+            area_model = sum(table_C[layer_name].loc[(table_C[layer_name]['in_both'] == 'model') |
+                                                     (table_C[layer_name]['in_both'] == 'both')].geom_area_model)
+            area_DAMO = sum(table_C[layer_name].loc[(table_C[layer_name]['in_both'] == 'damo') |
+                                                    (table_C[layer_name]['in_both'] == 'both')].geom_area_damo)
+            area_diff = area_model - area_DAMO
+            statistics.loc[layer_name, :] = [count_DAMO, count_model, count_diff, length_DAMO, length_model,
+                                             length_diff, area_DAMO, area_model, area_diff]
+        statistics = statistics.fillna(0).astype(int)
+        return statistics
+
+    def export_comparison(self, table_C, statistics, filename, overwrite=False, styling_path=None):
+        """
+        Exports all compared layers and statistics to a GeoPackage.
+
+        :param table_C: Dictionary containing a GeoDataframe per layer
+        :param statistics: Dataframe containing the statistics
+        :param filename: Filename of the GeoPackage to export to
+        :param overwrite: If true it will delete the old GeoPackage
+        :param styling_path: Path to folder containing .qml files. For each layer in table_C it will lookup a .qml file
+        with the exact same name as the layer
+        :return:
+        """
+
+        table = []
+        if Path(filename).exists():
+            if overwrite:
+                Path.unlink(filename)
+            else:
+                raise FileExistsError(
+                    f'The file "{filename}" already exists. If you want to overwrite the existing file, add overwrite=True to the function.')
+
+        # Explode multipart geometries to singleparts
+        for layer_name in list(table_C):
+            table_C[layer_name] = table_C[layer_name].explode(index_parts=True)
+
+        # export result to gpkg
+        for layer_name in list(table_C):
+            if len(table_C[layer_name].geometry.type.unique()) > 1:
+                self.logger.debug(
+                    f"Layer {layer_name} exists of the following geometry types: {table_C[layer_name].geometry.type.unique()}. Using representative point.")
+                table_C[layer_name].geometry = table_C[layer_name].geometry.representative_point()
+
+        for i, layer_name in enumerate(table_C):
+            # Check if the layer name has a style in the styling folder
+            if styling_path is not None:
+                qml_name = layer_name + ".qml"
+                qml_file = styling_path / qml_name
+
+                # if file exists, use that for the styling
+                if qml_file.exists():
+                    self.logger.debug(f"Style layer for layer {layer_name} found, adding it to the GeoPackage")
+                    with open(qml_file, "r") as file:
+                        style = file.read()
+                        style_name = layer_name + "_style"
+                        table.append(
+                            [i, None, None, layer_name, table_C[layer_name]._geometry_column_name, style_name,
+                             style, None, 'false', None, None, None, None])
+                else:
+                    if table_C[layer_name].geometry.type.unique() is None:
+                        pass
+                    if table_C[layer_name].geometry.type.unique() == 'Point':
+                        table.append(
+                            [i, None, None, layer_name, table_C[layer_name]._geometry_column_name, 'point_style',
+                             STYLING_POINTS_THREEDI, None, 'false', None, None, None, None])
+                    if table_C[layer_name].geometry.type.unique() == 'LineString' or table_C[
+                        layer_name].geometry.type.unique() == 'MultiLineString':
+                        table.append(
+                            [i, None, None, layer_name, table_C[layer_name]._geometry_column_name, 'line_style',
+                             STYLING_LINES_THREEDI, None, 'false', None, None, None, None])
+                    if table_C[layer_name].geometry.type.unique() == 'MultiPolygon':
+                        table.append(
+                            [i, None, None, layer_name, table_C[layer_name]._geometry_column_name, 'polygon_style',
+                             STYLING_POLYGONS_THREEDI, None, 'false', None, None, None, None])
+
+            self.logger.info(f"Export results of comparing DAMO/3Di layer {layer_name} to {filename}")
+            table_C[layer_name].to_file(filename, layer=layer_name, driver="GPKG", crs=self.crs)
+
+        # add styling to layers
+        layer_styles = gpd.GeoDataFrame(columns=STYLING_BASIC_TABLE_COLUMNS, data=table)
+        layer_styles.fillna("", inplace=True)
+        self.add_layer_styling(fn_export_gpkg=filename, layer_styles=layer_styles)
+
+        # Export statistics
+        self.export_statistics(statistics, filename)
+        self.logger.info(f"Finished exporting to {filename}")
+
+    def compare_with_DAMO(self, DAMO, attribute_comparison=None, filename=None, overwrite=False, styling_path=None):
+        """
+        Compares the Threedi object with a DAMO object.
+        Looks in all layers containing structures (defined in the config.py) for the 'code' column. Creates a joined
+        GeoDataFrame for each structure code ('KDU','KBR', etc., also defined in config.py)
+
+        :param DAMO: DAMO object
+        :param attribute_comparison: Path to JSON file containing attribute comparison
+        :param filename: Path to GeoPackage file to export the comparison to
+        :param overwrite: Boolean indicating if the export file can be overwritten if it already exists
+        :param styling_path: Path to folder containing .qml files for styling the layers
+        :return: Dictionary containing GeoDataframes with compared data and a Dataframe with statistics
+        """
+
+        # sort model and damo data by structure code instead of model and damo layers
+        table_struc_model = {}
+        table_struc_DAMO = {}
+        for struc in STRUCTURE_CODES:
+            table_struc_model[struc] = self.get_structure_by_code(struc, THREEDI_STRUCTURE_LAYERS)
+            table_struc_DAMO[struc] = DAMO.get_structure_by_code(struc, DAMO_HDB_STRUCTURE_LAYERS)
+
+        table_C = {}
+        for layer in table_struc_model.keys():
+
+            if table_struc_DAMO[layer].crs == table_struc_model[layer].crs:
+                self.logger.debug(f"CRS of DAMO and model data {layer} is equal")
+            else:
+                self.logger.debug(f"CRS of DAMO and model data {layer} is not equal")
+
+                table_struc_model[layer] = table_struc_model[layer].set_crs(epsg=4326).to_crs(
+                    crs=table_struc_DAMO[layer].crs)
+            self.crs = table_struc_DAMO[layer].crs
+
+            # Add geometry information (length/area) to dataframe
+            table_struc_model[layer] = self.add_geometry_info(table_struc_model[layer])
+            table_struc_DAMO[layer] = self.add_geometry_info(table_struc_DAMO[layer])
+
+            # Add 'dataset' column, after merging this will become 'dataset_model' and 'dataset_damo'
+            table_struc_model[layer]['dataset'] = True
+            table_struc_DAMO[layer]['dataset'] = True
+
+            # outer merge on the two tables with suffixes
+            table_struc_model[layer] = table_struc_model[layer].add_suffix('_model').rename(
+                columns={'code_model': 'code'})
+            table_struc_DAMO[layer] = table_struc_DAMO[layer].add_suffix('_damo').rename(columns={'code_damo': 'code'})
+
+            table_merged = table_struc_model[layer].merge(table_struc_DAMO[layer], how="outer", on='code')
+            table_merged['geometry'] = None
+            table_merged = gpd.GeoDataFrame(table_merged, geometry='geometry')
+            # fillna values of the two columns by False
+            table_merged[['dataset_model', 'dataset_damo']] = table_merged[['dataset_model', 'dataset_damo']].fillna(
+                value=False)
+
+            # add column with values model, damo or both, depending on code
+            inboth = []
+            for i in range(len(table_merged)):
+                if table_merged['dataset_model'][i] & table_merged['dataset_damo'][i]:
+                    inboth.append('both')
+                elif table_merged['dataset_model'][i] and not table_merged['dataset_damo'][i]:
+                    inboth.append('model')
+                else:
+                    inboth.append('damo')
+            table_merged['in_both'] = inboth
+
+            # use geometry of model when feature exists in model or in both model and damo. Use geometry of damo when feature only exists in damo
+            mask_geom_model = table_merged.loc[
+                (table_merged['in_both'] == 'model') | (table_merged['in_both'] == 'both')]
+            mask_geom_DAMO = table_merged.loc[table_merged['in_both'] == 'damo']
+            geom = pd.concat([mask_geom_model['geometry_model'], mask_geom_DAMO['geometry_damo']])
+            table_merged['geometry'] = geom
+            table_merged = self.drop_unused_geoseries(table_merged, keep='geometry')
+            if table_merged.columns.__contains__('the_geom_model'):
+                table_merged.drop(columns=['the_geom_model'], inplace=True)
+            table_C[layer] = gpd.GeoDataFrame(self.drop_unused_geoseries(table_merged, keep='geometry'),
+                                              geometry='geometry')
+
+        # Apply attribute comparison
+        if attribute_comparison is not None:
+            table_C = self.apply_attribute_comparison(attribute_comparison, table_C)
+            table_C = self.summarize_attribute_comparison(table_C)
+
+        # determine statistics: count amount of shapes per layer for model and damo
+        statistics = self.determine_statistics(table_C)
+
+        # export to filename
+        if filename is not None:
+            self.export_comparison(table_C, statistics, filename, overwrite=overwrite, styling_path=styling_path)
+
+        return table_C, statistics

--- a/hhnk_threedi_tools/core/vergelijkingstool/config.py
+++ b/hhnk_threedi_tools/core/vergelijkingstool/config.py
@@ -1,0 +1,79 @@
+SQLITE_LAYERS = [
+    'v2_connection_nodes',
+    'v2_cross_section_definition',
+    'v2_obstacle',
+    'v2_channel',
+    'v2_culvert',
+    'v2_cross_section_location',
+    'v2_orifice',
+    'v2_pumpstation',
+    'v2_weir',
+]
+
+SQLITE_LAYER_CROSS_SECTION_DEFINITION = 'v2_cross_section_definition'
+
+DAMO_LAYERS = [
+    'AfvoergebiedAanvoergebied',
+    'AquaductLijn', #Niet in beide datasets
+    'Bergingsgebied', #Niet in beide datasets
+    'Brug',
+    'Doorstroomopening',
+    'DuikerSifonHevel',
+    'Gemaal',
+    'GW_PBP',
+    'GW_PRO',
+    'GW_PRW',
+    'HydroObject',
+    #'IWS_GEO_BESCHR_PROFIELPUNTEN',
+    'PeilafwijkingGebied',
+    'PeilgebiedPraktijk',
+    'REF_BEHEERGEBIEDSGRENS_HHNK',
+    'Sluis',
+    'Stuw',
+    'VasteDam',
+    'Vispassage',
+    'Waterdeel',
+]
+
+HDB_LAYERS = [
+    'gemalen_op_peilgrens',
+    'stuwen_op_peilgrens',
+    'hydro_deelgebieden',
+    'Levee_overstromingsmodel',
+    'polderclusters',
+    'randvoorwaarden', #geen geom
+    'Sturing_3Di',
+]
+
+THREEDI_STRUCTURE_LAYERS = [
+    'v2_culvert',
+    'v2_pumpstation',
+    'v2_weir',
+    'v2_orifice',
+]
+
+DAMO_HDB_STRUCTURE_LAYERS = [
+    'gemalen_op_peilgrens',
+    'stuwen_op_peilgrens',
+    'brug',
+    'gemaal',
+    'duikersifonhevel',
+    'stuw',
+]
+
+STRUCTURE_CODES = [
+    'KDU',
+    'KST',
+    'KGM',
+    'KSY',
+    'KBR'
+    # @TODO: introduce 'other' category, so we don't miss any that don't have a nice code
+]
+
+GEOMETRICAL_COMPARISON_LAYERS = [
+    'PeilafwijkingGebied',
+    'PeilgebiedPraktijk',
+    'Waterdeel'
+]
+
+COMPARISON_GENERAL_THRESHOLD = 0.00001

--- a/hhnk_threedi_tools/core/vergelijkingstool/config.py
+++ b/hhnk_threedi_tools/core/vergelijkingstool/config.py
@@ -1,79 +1,75 @@
 SQLITE_LAYERS = [
-    'v2_connection_nodes',
-    'v2_cross_section_definition',
-    'v2_obstacle',
-    'v2_channel',
-    'v2_culvert',
-    'v2_cross_section_location',
-    'v2_orifice',
-    'v2_pumpstation',
-    'v2_weir',
+    "v2_connection_nodes",
+    "v2_cross_section_definition",
+    "v2_obstacle",
+    "v2_channel",
+    "v2_culvert",
+    "v2_cross_section_location",
+    "v2_orifice",
+    "v2_pumpstation",
+    "v2_weir",
 ]
 
-SQLITE_LAYER_CROSS_SECTION_DEFINITION = 'v2_cross_section_definition'
+SQLITE_LAYER_CROSS_SECTION_DEFINITION = "v2_cross_section_definition"
 
 DAMO_LAYERS = [
-    'AfvoergebiedAanvoergebied',
-    'AquaductLijn', #Niet in beide datasets
-    'Bergingsgebied', #Niet in beide datasets
-    'Brug',
-    'Doorstroomopening',
-    'DuikerSifonHevel',
-    'Gemaal',
-    'GW_PBP',
-    'GW_PRO',
-    'GW_PRW',
-    'HydroObject',
+    "AfvoergebiedAanvoergebied",
+    "AquaductLijn",  # Niet in beide datasets
+    "Bergingsgebied",  # Niet in beide datasets
+    "Brug",
+    "Doorstroomopening",
+    "DuikerSifonHevel",
+    "Gemaal",
+    "GW_PBP",
+    "GW_PRO",
+    "GW_PRW",
+    "HydroObject",
     #'IWS_GEO_BESCHR_PROFIELPUNTEN',
-    'PeilafwijkingGebied',
-    'PeilgebiedPraktijk',
-    'REF_BEHEERGEBIEDSGRENS_HHNK',
-    'Sluis',
-    'Stuw',
-    'VasteDam',
-    'Vispassage',
-    'Waterdeel',
+    "PeilafwijkingGebied",
+    "PeilgebiedPraktijk",
+    "REF_BEHEERGEBIEDSGRENS_HHNK",
+    "Sluis",
+    "Stuw",
+    "VasteDam",
+    "Vispassage",
+    "Waterdeel",
 ]
 
 HDB_LAYERS = [
-    'gemalen_op_peilgrens',
-    'stuwen_op_peilgrens',
-    'hydro_deelgebieden',
-    'Levee_overstromingsmodel',
-    'polderclusters',
-    'randvoorwaarden', #geen geom
-    'Sturing_3Di',
+    "gemalen_op_peilgrens",
+    "stuwen_op_peilgrens",
+    "hydro_deelgebieden",
+    "Levee_overstromingsmodel",
+    "polderclusters",
+    "randvoorwaarden",  # geen geom
+    "Sturing_3Di",
 ]
 
 THREEDI_STRUCTURE_LAYERS = [
-    'v2_culvert',
-    'v2_pumpstation',
-    'v2_weir',
-    'v2_orifice',
+    "v2_culvert",
+    "v2_pumpstation",
+    "v2_weir",
+    "v2_orifice",
 ]
 
 DAMO_HDB_STRUCTURE_LAYERS = [
-    'gemalen_op_peilgrens',
-    'stuwen_op_peilgrens',
-    'brug',
-    'gemaal',
-    'duikersifonhevel',
-    'stuw',
+    "gemalen_op_peilgrens",
+    "stuwen_op_peilgrens",
+    "brug",
+    "gemaal",
+    "duikersifonhevel",
+    "stuw",
 ]
 
 STRUCTURE_CODES = [
-    'KDU',
-    'KST',
-    'KGM',
-    'KSY',
-    'KBR'
+    "KDU",
+    "KST",
+    "KGM",
+    "KSY",
+    "KBR",
     # @TODO: introduce 'other' category, so we don't miss any that don't have a nice code
 ]
 
-GEOMETRICAL_COMPARISON_LAYERS = [
-    'PeilafwijkingGebied',
-    'PeilgebiedPraktijk',
-    'Waterdeel'
-]
+GEOMETRICAL_COMPARISON_LAYERS = ["PeilafwijkingGebied", "PeilgebiedPraktijk", "Waterdeel"]
 
 COMPARISON_GENERAL_THRESHOLD = 0.00001

--- a/hhnk_threedi_tools/core/vergelijkingstool/json_files/damo_attribute_comparison.json
+++ b/hhnk_threedi_tools/core/vergelijkingstool/json_files/damo_attribute_comparison.json
@@ -1,0 +1,271 @@
+{
+	"comparisons": [	
+			
+	
+	
+		{
+			"name": "cmp_bergend_vermogen",
+			"table": "bergingsgebied",
+			"type": "numeric",
+			"description":"Verschil in bergend vermogen",
+			"priority": "information",
+			"function": {
+				"difference": {
+					"left": "bergendvermogen_A",
+					"right": "bergendvermogen_B"
+				}
+			}
+		},
+		{
+			"name": "cmp_bergend_vermogen_peil",
+			"table": "bergingsgebied",
+			"type": "numeric",
+			"description":"Verschil in bergend vermogen peil",
+			"priority": "information",
+			"function": {
+				"difference": {
+					"left": "ws_bergend_vermogen_bij_peil_A",
+					"right": "ws_bergend_vermogen_bij_peil_B"
+				}
+			}
+		},
+		{
+			"name": "cmp_oppervlak",
+			"table": "bergingsgebied",
+			"type": "numeric",
+			"description":"Verschil in bergend vermogen",
+			"priority": "critical",
+			"function": {
+				"difference": {
+					"left": "geom_area_A",
+					"right": "geom_area_A"
+				}
+			}
+		},
+	
+	
+	
+		{
+			"name": "cmp_hoogteonderzijde",
+			"table": "brug",
+			"type": "numeric",
+			"description":"Verschil in hoogteonderzijde",
+			"priority": "critical",
+			"function": {
+				"difference": {
+					"left": "hoogteonderzijde_A",
+					"right": "hoogteonderzijde_B"
+				}
+			}
+		},
+		{
+			"name": "cmp_doorvaarbreedte",
+			"table": "brug",
+			"type": "numeric",
+			"description":"Verschil in doorvaarbreedte",
+			"priority": "critical",
+			"function": {
+				"difference": {
+					"left": "hoogteonderzijde_A",
+					"right": "hoogteonderzijde_B"
+				}
+			}
+		},
+		{
+			"name": "cmp_ws_categorie",
+			"table": "brug",
+			"type": "category",
+			"description":"Verschil in categorie",
+			"priority": "critical",
+			"left": "ws_categorie_A",
+			"right": "ws_categorie_B"
+
+		},		
+		{
+			"name": "cmp_aantal_doorstroomopeningen",
+			"table": "brug",
+			"type": "numeric",
+			"description":"Verschil in aantal doorstroomopeningen",
+			"priority": "critical",
+			"function": {
+				"difference": {
+					"left": "aantal_doorstroomopeningen_A",
+					"right": "aantal_doorstroomopeningen_B"
+				}
+			}
+		},
+		
+		
+		{
+			"name": "cmp_indicatiewaterkerend",
+			"table": "duikersifonhevel",
+			"type": "category",
+			"description":"Verschil in indicatiewaterkerend",
+			"priority": "critical",
+			"left": "indicatiewaterkerend_A",
+			"right": "indicatiewaterkerend_B"
+		},
+		{
+			"name": "cmp_indpeilregulpeilscheidend",
+			"table": "duikersifonhevel",
+			"type": "category",
+			"description":"Verschil in indpeilregulpeilscheidend",
+			"priority": "critical",
+			"left": "indpeilregulpeilscheidend_A",
+			"right": "indpeilregulpeilscheidend_B"
+		},		
+		{
+			"name": "cmp_hoogteopening",
+			"table": "duikersifonhevel",
+			"type": "numeric",
+			"description":"Verschil in aantal hoogteopening",
+			"priority": "critical",
+			"threshold": 0.1,
+			"function": {
+				"difference": {
+					"left": "hoogteopening_A",
+					"right": "hoogteopening_B"
+				}
+			}
+		},
+		{
+			"name": "cmp_breedteopening",
+			"table": "duikersifonhevel",
+			"type": "numeric",
+			"description":"Verschil in aantal breedteopening",
+			"priority": "critical",
+			"function": {
+				"difference": {
+					"left": "breedteopening_A",
+					"right": "breedteopening_B"
+				}
+			}
+		},
+		{
+			"name": "cmp_hoogtebinnenonderkantbenedenstrooms",
+			"table": "duikersifonhevel",
+			"type": "numeric",
+			"description":"Verschil in aantal hoogtebinnenonderkantbenedenstrooms",
+			"priority": "critical",
+			"function": {
+				"difference": {
+					"left": "hoogtebinnenonderkantbene_A",
+					"right": "hoogtebinnenonderkantbene_B"
+				}
+			}
+		},
+		{
+			"name": "cmp_hoogtebinnenonderkantbovenstrooms",
+			"table": "duikersifonhevel",
+			"type": "numeric",
+			"description":"Verschil in aantal hoogtebinnenonderkantbovenstrooms",
+			"priority": "critical",
+			"function": {
+				"difference": {
+					"left": "hoogtebinnenonderkantbov_A",
+					"right": "hoogtebinnenonderkantbov_B"
+				}
+			}
+		},
+		{
+			"name": "cmp_vormkoker",
+			"table": "duikersifonhevel",
+			"type": "category",
+			"description":"Verschil in vormkoker",
+			"priority": "critical",
+			"left": "vormkoker_A",
+			"right": "vormkoker_B"
+		},		
+		{
+			"name": "cmp_soortmateriaal",
+			"table": "duikersifonhevel",
+			"type": "category",
+			"description":"Verschil in soortmateriaal",
+			"priority": "critical",
+			"left": "soortmateriaal_A",
+			"right": "soortmateriaal_A"
+		},
+		{
+			"name": "cmp_typekruising",
+			"table": "duikersifonhevel",
+			"type": "category",
+			"description":"Verschil in typekruising",
+			"priority": "critical",
+			"left": "typekruising_A",
+			"right": "typekruising_B"
+		},				
+		{
+			"name": "cmp_ws_categorie",
+			"table": "duikersifonhevel",
+			"type": "category",
+			"description":"Verschil in ws_categorie",
+			"priority": "critical",
+			"left": "ws_categorie_A",
+			"right": "ws_categorie_B"
+		},
+		{
+			"name": "cmp_inlaatfunctie",
+			"table": "duikersifonhevel",
+			"type": "category",
+			"description":"Verschil in inlaatfunctie",
+			"priority": "critical",
+			"left": "ws_inlaatfunctie_A",
+			"right": "ws_inlaatfunctie_B"
+		},
+		{
+			"name": "cmp_ws_afsluitwijze1",
+			"table": "duikersifonhevel",
+			"type": "category",
+			"description":"Verschil in afsluitwijze 1",
+			"priority": "critical",
+			"left": "ws_afsluitwijze1_A",
+			"right": "ws_afsluitwijze1_B"
+		},
+		{
+			"name": "cmp_ws_afsluitwijze2",
+			"table": "duikersifonhevel",
+			"type": "category",
+			"description":"Verschil in afsluitwijze 2",
+			"priority": "warning",
+			"left": "ws_afsluitwijze2_A",
+			"right": "ws_afsluitwijze2_B"
+		},
+		{
+			"name": "cmp_geom_length",
+			"table": "duikersifonhevel",
+			"type": "numeric",
+			"description":"Verschil in lengte van geometrie",
+			"priority": "critical",
+			"function": {
+				"difference": {
+					"left": "geom_length_A",
+					"right": "geom_length_B"
+				}
+			}
+		},
+		
+		
+		{
+			"name": "cmp_functiegemaal",
+			"table": "gemaal",
+			"type": "category",
+			"description":"Verschil in functiegemaal",
+			"priority": "critical",
+			"left": "functiegemaal_A",
+			"right": "functiegemaal_B"
+		},
+		{
+			"name": "cmp_maximalecapaciteit",
+			"table": "gemaal",
+			"type": "numeric",
+			"description":"Verschil in maximale capaciteit",
+			"priority": "critical",
+			"function": {
+				"difference": {
+					"left": "maximalecapaciteit_A",
+					"right": "maximalecapaciteit_A"
+				}
+			}
+		}
+	]
+}

--- a/hhnk_threedi_tools/core/vergelijkingstool/json_files/damo_translation.json
+++ b/hhnk_threedi_tools/core/vergelijkingstool/json_files/damo_translation.json
@@ -1,0 +1,20 @@
+{
+	"GW_PRO": {
+		"name": "GW_PRO",
+		"columns": {
+			"PROIDENT": "code"
+		}
+	},
+	"Waterdeel": {
+		"name": "Waterdeel",
+		"columns": {
+			"identificatie": "code"
+		}
+	},
+	"GW_PRW": {
+		"name": "GW_PRW",
+		"columns": {
+			"PRW_ID": "code"
+		}
+	}
+}

--- a/hhnk_threedi_tools/core/vergelijkingstool/json_files/hdb_translation.json
+++ b/hhnk_threedi_tools/core/vergelijkingstool/json_files/hdb_translation.json
@@ -1,0 +1,18 @@
+{
+	"gemalen_op_peilgrens": {
+		"name": "gemalen_op_peilgrens",
+		"columns": {
+			"CODE": "code",
+			"WS_CATEGORIE": "ws_categorie",
+			"geometry": "geometry"
+		}
+	},
+    "stuwen_op_peilgrens": {
+		"name": "stuwen_op_peilgrens",
+		"columns": {
+			"CODE": "code",
+			"kruinhoogte_hdb": "kruinhoogte",
+			"geometry": "geometry"
+		}
+	}
+}

--- a/hhnk_threedi_tools/core/vergelijkingstool/json_files/threedi_translation.json
+++ b/hhnk_threedi_tools/core/vergelijkingstool/json_files/threedi_translation.json
@@ -1,0 +1,8 @@
+{
+    "v2_weir": {
+        "name": "v2_weir",
+        "columns": {
+            "code": "code"
+        }
+    }
+}

--- a/hhnk_threedi_tools/core/vergelijkingstool/main.py
+++ b/hhnk_threedi_tools/core/vergelijkingstool/main.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-""" Module for the comparison of DAMO/HDB data and 3Di model data.
+"""Module for the comparison of DAMO/HDB data and 3Di model data.
 With this module the actuality of 3Di models can be assessed.
 There are two main usages within this module:
     1. Compare current DAMO/HDB data with the DAMO/HDB data that was used to build the model.
@@ -28,50 +28,51 @@ __status__ = "Production"
 __version__ = "1.1.0"
 
 import logging
-import geopandas as gpd
-from pathlib import Path
 import warnings
+from pathlib import Path
 
-from datamodels.Threedimodel import Threedimodel
-from datamodels.DAMO import DAMO
+import geopandas as gpd
 
-if __name__ == '__main__':
+from hhnk_threedi_tools.core.vergelijkingstool.DAMO import DAMO
+from hhnk_threedi_tools.core.vergelijkingstool.Threedimodel import Threedimodel
+
+if __name__ == "__main__":
     # Set logging level
     logging.basicConfig(level=logging.INFO)
 
     # Supress fiona logging to keep logging readable
     for log_name, log_obj in logging.Logger.manager.loggerDict.items():
-        if log_name.__contains__('fiona'):
+        if log_name.__contains__("fiona"):
             log_obj.disabled = True
 
     # Supress GeoSeries.notna warning, as it warns about a changed operator. Currently using the new operator.
-    warnings.filterwarnings('ignore', 'GeoSeries.notna', UserWarning)
+    warnings.filterwarnings("ignore", "GeoSeries.notna", UserWarning)
 
     # Define all the paths of the input data
-    fn_damo_old = Path(r'data\input\Zijpe\old\DAMO.gdb')
-    fn_damo_old_translation = Path(r'data\input\Zijpe\old\damo_translation.json')
+    fn_damo_old = Path(r"data\input\Zijpe\old\DAMO.gdb")
+    fn_damo_old_translation = Path(r"data\input\Zijpe\old\damo_translation.json")
 
-    fn_damo_new = Path(r'data\input\Zijpe\new\DAMO.gdb')
-    fn_damo_new_translation = Path(r'data\input\Zijpe\new\damo_translation.json')
+    fn_damo_new = Path(r"data\input\Zijpe\new\DAMO.gdb")
+    fn_damo_new_translation = Path(r"data\input\Zijpe\new\damo_translation.json")
 
-    fn_hdb_old = Path(r'data\input\Zijpe\old\HDB.gdb')
-    fn_hdb_old_translation = Path(r'data\input\Zijpe\old\hdb_translation.json')
+    fn_hdb_old = Path(r"data\input\Zijpe\old\HDB.gdb")
+    fn_hdb_old_translation = Path(r"data\input\Zijpe\old\hdb_translation.json")
 
-    fn_hdb_new = Path(r'data\input\Zijpe\new\HDB.gdb')
-    fn_hdb_new_translation = Path(r'data\input\Zijpe\new\hdb_translation.json')
+    fn_hdb_new = Path(r"data\input\Zijpe\new\HDB.gdb")
+    fn_hdb_new_translation = Path(r"data\input\Zijpe\new\hdb_translation.json")
 
-    fn_threedimodel = Path(r'data\input\Zijpe\model\Zijpe.sqlite')
-    fn_threedimodel_translation = Path(r'data\input\Zijpe\model\threedi_translation.json')
+    fn_threedimodel = Path(r"data\input\Zijpe\model\Zijpe.sqlite")
+    fn_threedimodel_translation = Path(r"data\input\Zijpe\model\threedi_translation.json")
 
-    fn_damo_attribute_comparison = Path(r'data\input\Zijpe\damo_attribute_comparison.json')
-    fn_model_attribute_comparison = Path(r'data\input\Zijpe\model_attribute_comparison.json')
+    fn_damo_attribute_comparison = Path(r"data\input\Zijpe\damo_attribute_comparison.json")
+    fn_model_attribute_comparison = Path(r"data\input\Zijpe\model_attribute_comparison.json")
 
     # Define path where layer stylings can be found (for each layer it will search for <<LAYER_NAME>>.qml
-    styling_path = Path(r'data\input\Zijpe\styling')
+    styling_path = Path(r"data\input\Zijpe\styling")
 
     # Define output paths
-    fn_DAMO_comparison_export = Path(r'data\output\Zijpe\DAMO_comparison.gpkg')
-    fn_threedi_comparison_export = Path(r'data\output\Zijpe\Threedi_comparison.gpkg')
+    fn_DAMO_comparison_export = Path(r"data\output\Zijpe\DAMO_comparison.gpkg")
+    fn_threedi_comparison_export = Path(r"data\output\Zijpe\Threedi_comparison.gpkg")
 
     # Read selection geopackage (done here and not in a function because it might be that functionality is implemented
     # in a QGIS environment and the shape is passed in a different way
@@ -85,17 +86,20 @@ if __name__ == '__main__':
     damo_new = DAMO(fn_damo_new, fn_hdb_new, translation_DAMO=fn_damo_new_translation, clip_shape=selection_shape)
 
     # Compare damo objects with eachother and export result to geopackage
-    DAMO_comparison, DAMO_statistics = damo_new.compare_with_damo(damo_old,
-                                                                  attribute_comparison=fn_damo_attribute_comparison,
-                                                                  filename=fn_DAMO_comparison_export,
-                                                                  overwrite=True,
-                                                                  styling_path=styling_path)
+    DAMO_comparison, DAMO_statistics = damo_new.compare_with_damo(
+        damo_old,
+        attribute_comparison=fn_damo_attribute_comparison,
+        filename=fn_DAMO_comparison_export,
+        overwrite=True,
+        styling_path=styling_path,
+    )
 
     # Create Threedimodel object
     threedi_model = Threedimodel(fn_threedimodel, translation=fn_threedimodel_translation)
-    threedi_comparison, threedi_statistics = \
-        threedi_model.compare_with_DAMO(damo_new,
-                                        attribute_comparison=fn_model_attribute_comparison,
-                                        filename=fn_threedi_comparison_export,
-                                        overwrite=True,
-                                        styling_path=styling_path)
+    threedi_comparison, threedi_statistics = threedi_model.compare_with_DAMO(
+        damo_new,
+        attribute_comparison=fn_model_attribute_comparison,
+        filename=fn_threedi_comparison_export,
+        overwrite=True,
+        styling_path=styling_path,
+    )

--- a/hhnk_threedi_tools/core/vergelijkingstool/main.py
+++ b/hhnk_threedi_tools/core/vergelijkingstool/main.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+""" Module for the comparison of DAMO/HDB data and 3Di model data.
+With this module the actuality of 3Di models can be assessed.
+There are two main usages within this module:
+    1. Compare current DAMO/HDB data with the DAMO/HDB data that was used to build the model.
+    This gives an indication in how much the water system has changed
+    2. Compare the 3Di model with (current) DAMO/HDB data.
+    This gives an indication in how much the model differs from the (current) situation.
+    Possibly the model was updated in the years together with the DAMO/HDB or the datachecker/modelbuilder induced
+    differences
+
+Installation:
+The sqlite3 module needs some .dll's in order to unlock the spatial functionality.
+These .dll's need to be downloaded from http://www.gaia-gis.it/gaia-sins/.
+Under MS Windows binaries -> current stable version -> choose x86 or amd64 -> mod_spatialite-x.x.x-win-xxx.7z.
+Module was tested with http://www.gaia-gis.it/gaia-sins/windows-bin-amd64/mod_spatialite-5.0.1-win-amd64.7z
+Unpack content of .7z file and place them in the C:\\Windows\\System32 folder
+"""
+
+__authors__ = ["Thijs van den Pol (Royal HaskoningDHV)", "Emiel Verstegen (Royal HaskoningDHV)"]
+__contact__ = "emiel.verstegen@rhdhv.com"
+__credits__ = ["Thijs van den Pol", "Emiel Verstegen"]
+__date__ = "2023/03/13"
+__deprecated__ = False
+__email__ = "emiel.verstegen@rhdhv.com"
+__maintainer__ = "developer"
+__status__ = "Production"
+__version__ = "1.1.0"
+
+import logging
+import geopandas as gpd
+from pathlib import Path
+import warnings
+
+from datamodels.Threedimodel import Threedimodel
+from datamodels.DAMO import DAMO
+
+if __name__ == '__main__':
+    # Set logging level
+    logging.basicConfig(level=logging.INFO)
+
+    # Supress fiona logging to keep logging readable
+    for log_name, log_obj in logging.Logger.manager.loggerDict.items():
+        if log_name.__contains__('fiona'):
+            log_obj.disabled = True
+
+    # Supress GeoSeries.notna warning, as it warns about a changed operator. Currently using the new operator.
+    warnings.filterwarnings('ignore', 'GeoSeries.notna', UserWarning)
+
+    # Define all the paths of the input data
+    fn_damo_old = Path(r'data\input\Zijpe\old\DAMO.gdb')
+    fn_damo_old_translation = Path(r'data\input\Zijpe\old\damo_translation.json')
+
+    fn_damo_new = Path(r'data\input\Zijpe\new\DAMO.gdb')
+    fn_damo_new_translation = Path(r'data\input\Zijpe\new\damo_translation.json')
+
+    fn_hdb_old = Path(r'data\input\Zijpe\old\HDB.gdb')
+    fn_hdb_old_translation = Path(r'data\input\Zijpe\old\hdb_translation.json')
+
+    fn_hdb_new = Path(r'data\input\Zijpe\new\HDB.gdb')
+    fn_hdb_new_translation = Path(r'data\input\Zijpe\new\hdb_translation.json')
+
+    fn_threedimodel = Path(r'data\input\Zijpe\model\Zijpe.sqlite')
+    fn_threedimodel_translation = Path(r'data\input\Zijpe\model\threedi_translation.json')
+
+    fn_damo_attribute_comparison = Path(r'data\input\Zijpe\damo_attribute_comparison.json')
+    fn_model_attribute_comparison = Path(r'data\input\Zijpe\model_attribute_comparison.json')
+
+    # Define path where layer stylings can be found (for each layer it will search for <<LAYER_NAME>>.qml
+    styling_path = Path(r'data\input\Zijpe\styling')
+
+    # Define output paths
+    fn_DAMO_comparison_export = Path(r'data\output\Zijpe\DAMO_comparison.gpkg')
+    fn_threedi_comparison_export = Path(r'data\output\Zijpe\Threedi_comparison.gpkg')
+
+    # Read selection geopackage (done here and not in a function because it might be that functionality is implemented
+    # in a QGIS environment and the shape is passed in a different way
+    fn_DAMO_selection = r"data\input\Zijpe\damo_selection.gpkg"
+    gdf_selection = gpd.read_file(fn_DAMO_selection)
+    selection_shape = gdf_selection.unary_union
+
+    # Create two damo_objects, supply with DAMO-file, HDB-file and optionally a translation_DAMO, translation_HDB or a
+    # clip_shape
+    damo_old = DAMO(fn_damo_old, fn_hdb_old, translation_DAMO=fn_damo_old_translation, clip_shape=selection_shape)
+    damo_new = DAMO(fn_damo_new, fn_hdb_new, translation_DAMO=fn_damo_new_translation, clip_shape=selection_shape)
+
+    # Compare damo objects with eachother and export result to geopackage
+    DAMO_comparison, DAMO_statistics = damo_new.compare_with_damo(damo_old,
+                                                                  attribute_comparison=fn_damo_attribute_comparison,
+                                                                  filename=fn_DAMO_comparison_export,
+                                                                  overwrite=True,
+                                                                  styling_path=styling_path)
+
+    # Create Threedimodel object
+    threedi_model = Threedimodel(fn_threedimodel, translation=fn_threedimodel_translation)
+    threedi_comparison, threedi_statistics = \
+        threedi_model.compare_with_DAMO(damo_new,
+                                        attribute_comparison=fn_model_attribute_comparison,
+                                        filename=fn_threedi_comparison_export,
+                                        overwrite=True,
+                                        styling_path=styling_path)

--- a/hhnk_threedi_tools/core/vergelijkingstool/styling.py
+++ b/hhnk_threedi_tools/core/vergelijkingstool/styling.py
@@ -1,0 +1,1521 @@
+STYLING_BASIC_TABLE_COLUMNS = ['id', 'f_table_catalog', 'f_table_schema', 'f_table_name', 'f_geometry_column', 'styleName', 'styleQML', 'styleSLD', 'useAsDefault', 'description', 'owner', 'ui', 'update_time']
+
+STYLING_POINTS_DAMO = r"""
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.22.4-Białowieża" styleCategories="Symbology">
+  <renderer-v2 symbollevels="0" forceraster="0" enableorderby="0" type="categorizedSymbol" attr="in_both" referencescale="-1">
+    <categories>
+      <category symbol="0" render="true" label="A" value="A"/>
+      <category symbol="1" render="true" label="B" value="B"/>
+      <category symbol="2" render="true" label="AB" value="AB"/>
+    </categories>
+    <symbols>
+      <symbol alpha="1" force_rhr="0" clip_to_extent="1" type="marker" name="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" pass="0" enabled="1" locked="0">
+          <Option type="Map">
+            <Option value="0" type="QString" name="angle"/>
+            <Option value="square" type="QString" name="cap_style"/>
+            <Option value="255,127,0,255" type="QString" name="color"/>
+            <Option value="1" type="QString" name="horizontal_anchor_point"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="circle" type="QString" name="name"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="35,35,35,255" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0" type="QString" name="outline_width"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="diameter" type="QString" name="scale_method"/>
+            <Option value="2" type="QString" name="size"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="size_map_unit_scale"/>
+            <Option value="MM" type="QString" name="size_unit"/>
+            <Option value="1" type="QString" name="vertical_anchor_point"/>
+          </Option>
+          <prop v="0" k="angle"/>
+          <prop v="square" k="cap_style"/>
+          <prop v="255,127,0,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="circle" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="diameter" k="scale_method"/>
+          <prop v="2" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MM" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol alpha="1" force_rhr="0" clip_to_extent="1" type="marker" name="1">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" pass="0" enabled="1" locked="0">
+          <Option type="Map">
+            <Option value="0" type="QString" name="angle"/>
+            <Option value="square" type="QString" name="cap_style"/>
+            <Option value="62,131,249,255" type="QString" name="color"/>
+            <Option value="1" type="QString" name="horizontal_anchor_point"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="circle" type="QString" name="name"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="35,35,35,255" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0" type="QString" name="outline_width"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="diameter" type="QString" name="scale_method"/>
+            <Option value="2" type="QString" name="size"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="size_map_unit_scale"/>
+            <Option value="MM" type="QString" name="size_unit"/>
+            <Option value="1" type="QString" name="vertical_anchor_point"/>
+          </Option>
+          <prop v="0" k="angle"/>
+          <prop v="square" k="cap_style"/>
+          <prop v="62,131,249,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="circle" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="diameter" k="scale_method"/>
+          <prop v="2" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MM" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol alpha="1" force_rhr="0" clip_to_extent="1" type="marker" name="2">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" pass="0" enabled="1" locked="0">
+          <Option type="Map">
+            <Option value="0" type="QString" name="angle"/>
+            <Option value="square" type="QString" name="cap_style"/>
+            <Option value="197,197,197,128" type="QString" name="color"/>
+            <Option value="1" type="QString" name="horizontal_anchor_point"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="circle" type="QString" name="name"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="35,35,35,255" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0" type="QString" name="outline_width"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="diameter" type="QString" name="scale_method"/>
+            <Option value="2" type="QString" name="size"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="size_map_unit_scale"/>
+            <Option value="MM" type="QString" name="size_unit"/>
+            <Option value="1" type="QString" name="vertical_anchor_point"/>
+          </Option>
+          <prop v="0" k="angle"/>
+          <prop v="square" k="cap_style"/>
+          <prop v="197,197,197,128" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="circle" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="diameter" k="scale_method"/>
+          <prop v="2" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MM" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+    <source-symbol>
+      <symbol alpha="1" force_rhr="0" clip_to_extent="1" type="marker" name="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" pass="0" enabled="1" locked="0">
+          <Option type="Map">
+            <Option value="0" type="QString" name="angle"/>
+            <Option value="square" type="QString" name="cap_style"/>
+            <Option value="164,113,88,255" type="QString" name="color"/>
+            <Option value="1" type="QString" name="horizontal_anchor_point"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="circle" type="QString" name="name"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="35,35,35,255" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0" type="QString" name="outline_width"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="diameter" type="QString" name="scale_method"/>
+            <Option value="2" type="QString" name="size"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="size_map_unit_scale"/>
+            <Option value="MM" type="QString" name="size_unit"/>
+            <Option value="1" type="QString" name="vertical_anchor_point"/>
+          </Option>
+          <prop v="0" k="angle"/>
+          <prop v="square" k="cap_style"/>
+          <prop v="164,113,88,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="circle" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="diameter" k="scale_method"/>
+          <prop v="2" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MM" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </source-symbol>
+    <rotation/>
+    <sizescale/>
+  </renderer-v2>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerGeometryType>0</layerGeometryType>
+</qgis>
+"""
+
+STYLING_LINES_DAMO = """
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.22.4-Białowieża" styleCategories="Symbology">
+  <renderer-v2 symbollevels="0" forceraster="0" enableorderby="0" type="categorizedSymbol" attr="in_both" referencescale="-1">
+    <categories>
+      <category symbol="0" render="true" label="A" value="A"/>
+      <category symbol="1" render="true" label="B" value="B"/>
+      <category symbol="2" render="true" label="AB" value="AB"/>
+    </categories>
+    <symbols>
+      <symbol alpha="1" force_rhr="0" clip_to_extent="1" type="line" name="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleLine" pass="0" enabled="1" locked="0">
+          <Option type="Map">
+            <Option value="0" type="QString" name="align_dash_pattern"/>
+            <Option value="square" type="QString" name="capstyle"/>
+            <Option value="5;2" type="QString" name="customdash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
+            <Option value="MM" type="QString" name="customdash_unit"/>
+            <Option value="0" type="QString" name="dash_pattern_offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
+            <Option value="0" type="QString" name="draw_inside_polygon"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="255,127,0,255" type="QString" name="line_color"/>
+            <Option value="solid" type="QString" name="line_style"/>
+            <Option value="1" type="QString" name="line_width"/>
+            <Option value="MM" type="QString" name="line_width_unit"/>
+            <Option value="0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0" type="QString" name="ring_filter"/>
+            <Option value="0" type="QString" name="trim_distance_end"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
+            <Option value="0" type="QString" name="trim_distance_start"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
+            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
+            <Option value="0" type="QString" name="use_custom_dash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
+          </Option>
+          <prop v="0" k="align_dash_pattern"/>
+          <prop v="square" k="capstyle"/>
+          <prop v="5;2" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="MM" k="customdash_unit"/>
+          <prop v="0" k="dash_pattern_offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
+          <prop v="MM" k="dash_pattern_offset_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="255,127,0,255" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="1" k="line_width"/>
+          <prop v="MM" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="trim_distance_end"/>
+          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
+          <prop v="MM" k="trim_distance_end_unit"/>
+          <prop v="0" k="trim_distance_start"/>
+          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
+          <prop v="MM" k="trim_distance_start_unit"/>
+          <prop v="0" k="tweak_dash_pattern_on_corners"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol alpha="1" force_rhr="0" clip_to_extent="1" type="line" name="1">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleLine" pass="0" enabled="1" locked="0">
+          <Option type="Map">
+            <Option value="0" type="QString" name="align_dash_pattern"/>
+            <Option value="square" type="QString" name="capstyle"/>
+            <Option value="5;2" type="QString" name="customdash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
+            <Option value="MM" type="QString" name="customdash_unit"/>
+            <Option value="0" type="QString" name="dash_pattern_offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
+            <Option value="0" type="QString" name="draw_inside_polygon"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="62,131,249,255" type="QString" name="line_color"/>
+            <Option value="solid" type="QString" name="line_style"/>
+            <Option value="1" type="QString" name="line_width"/>
+            <Option value="MM" type="QString" name="line_width_unit"/>
+            <Option value="0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0" type="QString" name="ring_filter"/>
+            <Option value="0" type="QString" name="trim_distance_end"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
+            <Option value="0" type="QString" name="trim_distance_start"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
+            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
+            <Option value="0" type="QString" name="use_custom_dash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
+          </Option>
+          <prop v="0" k="align_dash_pattern"/>
+          <prop v="square" k="capstyle"/>
+          <prop v="5;2" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="MM" k="customdash_unit"/>
+          <prop v="0" k="dash_pattern_offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
+          <prop v="MM" k="dash_pattern_offset_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="62,131,249,255" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="1" k="line_width"/>
+          <prop v="MM" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="trim_distance_end"/>
+          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
+          <prop v="MM" k="trim_distance_end_unit"/>
+          <prop v="0" k="trim_distance_start"/>
+          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
+          <prop v="MM" k="trim_distance_start_unit"/>
+          <prop v="0" k="tweak_dash_pattern_on_corners"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol alpha="1" force_rhr="0" clip_to_extent="1" type="line" name="2">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleLine" pass="0" enabled="1" locked="0">
+          <Option type="Map">
+            <Option value="0" type="QString" name="align_dash_pattern"/>
+            <Option value="square" type="QString" name="capstyle"/>
+            <Option value="5;2" type="QString" name="customdash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
+            <Option value="MM" type="QString" name="customdash_unit"/>
+            <Option value="0" type="QString" name="dash_pattern_offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
+            <Option value="0" type="QString" name="draw_inside_polygon"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="197,197,197,128" type="QString" name="line_color"/>
+            <Option value="solid" type="QString" name="line_style"/>
+            <Option value="1" type="QString" name="line_width"/>
+            <Option value="MM" type="QString" name="line_width_unit"/>
+            <Option value="0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0" type="QString" name="ring_filter"/>
+            <Option value="0" type="QString" name="trim_distance_end"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
+            <Option value="0" type="QString" name="trim_distance_start"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
+            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
+            <Option value="0" type="QString" name="use_custom_dash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
+          </Option>
+          <prop v="0" k="align_dash_pattern"/>
+          <prop v="square" k="capstyle"/>
+          <prop v="5;2" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="MM" k="customdash_unit"/>
+          <prop v="0" k="dash_pattern_offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
+          <prop v="MM" k="dash_pattern_offset_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="197,197,197,128" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="1" k="line_width"/>
+          <prop v="MM" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="trim_distance_end"/>
+          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
+          <prop v="MM" k="trim_distance_end_unit"/>
+          <prop v="0" k="trim_distance_start"/>
+          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
+          <prop v="MM" k="trim_distance_start_unit"/>
+          <prop v="0" k="tweak_dash_pattern_on_corners"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+    <source-symbol>
+      <symbol alpha="1" force_rhr="0" clip_to_extent="1" type="line" name="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleLine" pass="0" enabled="1" locked="0">
+          <Option type="Map">
+            <Option value="0" type="QString" name="align_dash_pattern"/>
+            <Option value="square" type="QString" name="capstyle"/>
+            <Option value="5;2" type="QString" name="customdash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
+            <Option value="MM" type="QString" name="customdash_unit"/>
+            <Option value="0" type="QString" name="dash_pattern_offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
+            <Option value="0" type="QString" name="draw_inside_polygon"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="213,180,60,255" type="QString" name="line_color"/>
+            <Option value="solid" type="QString" name="line_style"/>
+            <Option value="1" type="QString" name="line_width"/>
+            <Option value="MM" type="QString" name="line_width_unit"/>
+            <Option value="0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0" type="QString" name="ring_filter"/>
+            <Option value="0" type="QString" name="trim_distance_end"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
+            <Option value="0" type="QString" name="trim_distance_start"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
+            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
+            <Option value="0" type="QString" name="use_custom_dash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
+          </Option>
+          <prop v="0" k="align_dash_pattern"/>
+          <prop v="square" k="capstyle"/>
+          <prop v="5;2" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="MM" k="customdash_unit"/>
+          <prop v="0" k="dash_pattern_offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
+          <prop v="MM" k="dash_pattern_offset_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="213,180,60,255" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="1" k="line_width"/>
+          <prop v="MM" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="trim_distance_end"/>
+          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
+          <prop v="MM" k="trim_distance_end_unit"/>
+          <prop v="0" k="trim_distance_start"/>
+          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
+          <prop v="MM" k="trim_distance_start_unit"/>
+          <prop v="0" k="tweak_dash_pattern_on_corners"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </source-symbol>
+    <rotation/>
+    <sizescale/>
+  </renderer-v2>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerGeometryType>1</layerGeometryType>
+</qgis>
+"""
+
+STYLING_POLYGONS_DAMO = """
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.22.4-Białowieża" styleCategories="Symbology">
+  <renderer-v2 symbollevels="0" forceraster="0" enableorderby="0" type="categorizedSymbol" attr="in_both" referencescale="-1">
+    <categories>
+      <category symbol="0" render="true" label="A" value="A"/>
+      <category symbol="1" render="true" label="B" value="B"/>
+      <category symbol="2" render="true" label="AB" value="AB"/>
+    </categories>
+    <symbols>
+      <symbol alpha="1" force_rhr="0" clip_to_extent="1" type="fill" name="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleFill" pass="0" enabled="1" locked="0">
+          <Option type="Map">
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="255,127,0,255" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="35,35,35,255" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.26" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
+          </Option>
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="255,127,0,255" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.26" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol alpha="1" force_rhr="0" clip_to_extent="1" type="fill" name="1">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleFill" pass="0" enabled="1" locked="0">
+          <Option type="Map">
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="62,131,249,255" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="35,35,35,255" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.26" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
+          </Option>
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="62,131,249,255" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.26" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol alpha="1" force_rhr="0" clip_to_extent="1" type="fill" name="2">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleFill" pass="0" enabled="1" locked="0">
+          <Option type="Map">
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="197,197,197,128" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="35,35,35,255" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.26" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
+          </Option>
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="197,197,197,128" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.26" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+    <source-symbol>
+      <symbol alpha="1" force_rhr="0" clip_to_extent="1" type="fill" name="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleFill" pass="0" enabled="1" locked="0">
+          <Option type="Map">
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="141,90,153,255" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="35,35,35,255" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.26" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
+          </Option>
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="141,90,153,255" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.26" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </source-symbol>
+    <rotation/>
+    <sizescale/>
+  </renderer-v2>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerGeometryType>2</layerGeometryType>
+</qgis>
+"""
+
+STYLING_POINTS_THREEDI = """<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.22.4-Białowieża" styleCategories="Symbology">
+  <renderer-v2 symbollevels="0" forceraster="0" enableorderby="0" type="categorizedSymbol" attr="in_both" referencescale="-1">
+    <categories>
+      <category symbol="0" render="true" label="Damo" value="damo"/>
+      <category symbol="1" render="true" label="Model" value="model"/>
+      <category symbol="2" render="true" label="Both" value="both"/>
+    </categories>
+    <symbols>
+      <symbol alpha="1" force_rhr="0" clip_to_extent="1" type="marker" name="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" pass="0" enabled="1" locked="0">
+          <Option type="Map">
+            <Option value="0" type="QString" name="angle"/>
+            <Option value="square" type="QString" name="cap_style"/>
+            <Option value="255,127,0,255" type="QString" name="color"/>
+            <Option value="1" type="QString" name="horizontal_anchor_point"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="circle" type="QString" name="name"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="35,35,35,255" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0" type="QString" name="outline_width"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="diameter" type="QString" name="scale_method"/>
+            <Option value="2" type="QString" name="size"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="size_map_unit_scale"/>
+            <Option value="MM" type="QString" name="size_unit"/>
+            <Option value="1" type="QString" name="vertical_anchor_point"/>
+          </Option>
+          <prop v="0" k="angle"/>
+          <prop v="square" k="cap_style"/>
+          <prop v="255,127,0,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="circle" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="diameter" k="scale_method"/>
+          <prop v="2" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MM" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol alpha="1" force_rhr="0" clip_to_extent="1" type="marker" name="1">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" pass="0" enabled="1" locked="0">
+          <Option type="Map">
+            <Option value="0" type="QString" name="angle"/>
+            <Option value="square" type="QString" name="cap_style"/>
+            <Option value="62,131,249,255" type="QString" name="color"/>
+            <Option value="1" type="QString" name="horizontal_anchor_point"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="circle" type="QString" name="name"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="35,35,35,255" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0" type="QString" name="outline_width"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="diameter" type="QString" name="scale_method"/>
+            <Option value="2" type="QString" name="size"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="size_map_unit_scale"/>
+            <Option value="MM" type="QString" name="size_unit"/>
+            <Option value="1" type="QString" name="vertical_anchor_point"/>
+          </Option>
+          <prop v="0" k="angle"/>
+          <prop v="square" k="cap_style"/>
+          <prop v="62,131,249,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="circle" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="diameter" k="scale_method"/>
+          <prop v="2" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MM" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol alpha="1" force_rhr="0" clip_to_extent="1" type="marker" name="2">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" pass="0" enabled="1" locked="0">
+          <Option type="Map">
+            <Option value="0" type="QString" name="angle"/>
+            <Option value="square" type="QString" name="cap_style"/>
+            <Option value="197,197,197,128" type="QString" name="color"/>
+            <Option value="1" type="QString" name="horizontal_anchor_point"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="circle" type="QString" name="name"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="35,35,35,255" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0" type="QString" name="outline_width"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="diameter" type="QString" name="scale_method"/>
+            <Option value="2" type="QString" name="size"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="size_map_unit_scale"/>
+            <Option value="MM" type="QString" name="size_unit"/>
+            <Option value="1" type="QString" name="vertical_anchor_point"/>
+          </Option>
+          <prop v="0" k="angle"/>
+          <prop v="square" k="cap_style"/>
+          <prop v="197,197,197,128" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="circle" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="diameter" k="scale_method"/>
+          <prop v="2" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MM" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+    <source-symbol>
+      <symbol alpha="1" force_rhr="0" clip_to_extent="1" type="marker" name="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" pass="0" enabled="1" locked="0">
+          <Option type="Map">
+            <Option value="0" type="QString" name="angle"/>
+            <Option value="square" type="QString" name="cap_style"/>
+            <Option value="164,113,88,255" type="QString" name="color"/>
+            <Option value="1" type="QString" name="horizontal_anchor_point"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="circle" type="QString" name="name"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="35,35,35,255" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0" type="QString" name="outline_width"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="diameter" type="QString" name="scale_method"/>
+            <Option value="2" type="QString" name="size"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="size_map_unit_scale"/>
+            <Option value="MM" type="QString" name="size_unit"/>
+            <Option value="1" type="QString" name="vertical_anchor_point"/>
+          </Option>
+          <prop v="0" k="angle"/>
+          <prop v="square" k="cap_style"/>
+          <prop v="164,113,88,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="circle" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="diameter" k="scale_method"/>
+          <prop v="2" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MM" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </source-symbol>
+    <rotation/>
+    <sizescale/>
+  </renderer-v2>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerGeometryType>0</layerGeometryType>
+</qgis>"""
+
+STYLING_LINES_THREEDI = """<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.22.4-Białowieża" styleCategories="Symbology">
+  <renderer-v2 symbollevels="0" forceraster="0" enableorderby="0" type="categorizedSymbol" attr="in_both" referencescale="-1">
+    <categories>
+      <category symbol="0" render="true" label="Damo" value="damo"/>
+      <category symbol="1" render="true" label="Model" value="model"/>
+      <category symbol="2" render="true" label="Both" value="both"/>
+    </categories>
+    <symbols>
+      <symbol alpha="1" force_rhr="0" clip_to_extent="1" type="line" name="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleLine" pass="0" enabled="1" locked="0">
+          <Option type="Map">
+            <Option value="0" type="QString" name="align_dash_pattern"/>
+            <Option value="square" type="QString" name="capstyle"/>
+            <Option value="5;2" type="QString" name="customdash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
+            <Option value="MM" type="QString" name="customdash_unit"/>
+            <Option value="0" type="QString" name="dash_pattern_offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
+            <Option value="0" type="QString" name="draw_inside_polygon"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="255,127,0,255" type="QString" name="line_color"/>
+            <Option value="solid" type="QString" name="line_style"/>
+            <Option value="1" type="QString" name="line_width"/>
+            <Option value="MM" type="QString" name="line_width_unit"/>
+            <Option value="0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0" type="QString" name="ring_filter"/>
+            <Option value="0" type="QString" name="trim_distance_end"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
+            <Option value="0" type="QString" name="trim_distance_start"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
+            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
+            <Option value="0" type="QString" name="use_custom_dash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
+          </Option>
+          <prop v="0" k="align_dash_pattern"/>
+          <prop v="square" k="capstyle"/>
+          <prop v="5;2" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="MM" k="customdash_unit"/>
+          <prop v="0" k="dash_pattern_offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
+          <prop v="MM" k="dash_pattern_offset_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="255,127,0,255" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="1" k="line_width"/>
+          <prop v="MM" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="trim_distance_end"/>
+          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
+          <prop v="MM" k="trim_distance_end_unit"/>
+          <prop v="0" k="trim_distance_start"/>
+          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
+          <prop v="MM" k="trim_distance_start_unit"/>
+          <prop v="0" k="tweak_dash_pattern_on_corners"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol alpha="1" force_rhr="0" clip_to_extent="1" type="line" name="1">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleLine" pass="0" enabled="1" locked="0">
+          <Option type="Map">
+            <Option value="0" type="QString" name="align_dash_pattern"/>
+            <Option value="square" type="QString" name="capstyle"/>
+            <Option value="5;2" type="QString" name="customdash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
+            <Option value="MM" type="QString" name="customdash_unit"/>
+            <Option value="0" type="QString" name="dash_pattern_offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
+            <Option value="0" type="QString" name="draw_inside_polygon"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="62,131,249,255" type="QString" name="line_color"/>
+            <Option value="solid" type="QString" name="line_style"/>
+            <Option value="1" type="QString" name="line_width"/>
+            <Option value="MM" type="QString" name="line_width_unit"/>
+            <Option value="0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0" type="QString" name="ring_filter"/>
+            <Option value="0" type="QString" name="trim_distance_end"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
+            <Option value="0" type="QString" name="trim_distance_start"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
+            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
+            <Option value="0" type="QString" name="use_custom_dash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
+          </Option>
+          <prop v="0" k="align_dash_pattern"/>
+          <prop v="square" k="capstyle"/>
+          <prop v="5;2" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="MM" k="customdash_unit"/>
+          <prop v="0" k="dash_pattern_offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
+          <prop v="MM" k="dash_pattern_offset_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="62,131,249,255" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="1" k="line_width"/>
+          <prop v="MM" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="trim_distance_end"/>
+          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
+          <prop v="MM" k="trim_distance_end_unit"/>
+          <prop v="0" k="trim_distance_start"/>
+          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
+          <prop v="MM" k="trim_distance_start_unit"/>
+          <prop v="0" k="tweak_dash_pattern_on_corners"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol alpha="1" force_rhr="0" clip_to_extent="1" type="line" name="2">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleLine" pass="0" enabled="1" locked="0">
+          <Option type="Map">
+            <Option value="0" type="QString" name="align_dash_pattern"/>
+            <Option value="square" type="QString" name="capstyle"/>
+            <Option value="5;2" type="QString" name="customdash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
+            <Option value="MM" type="QString" name="customdash_unit"/>
+            <Option value="0" type="QString" name="dash_pattern_offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
+            <Option value="0" type="QString" name="draw_inside_polygon"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="197,197,197,128" type="QString" name="line_color"/>
+            <Option value="solid" type="QString" name="line_style"/>
+            <Option value="1" type="QString" name="line_width"/>
+            <Option value="MM" type="QString" name="line_width_unit"/>
+            <Option value="0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0" type="QString" name="ring_filter"/>
+            <Option value="0" type="QString" name="trim_distance_end"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
+            <Option value="0" type="QString" name="trim_distance_start"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
+            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
+            <Option value="0" type="QString" name="use_custom_dash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
+          </Option>
+          <prop v="0" k="align_dash_pattern"/>
+          <prop v="square" k="capstyle"/>
+          <prop v="5;2" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="MM" k="customdash_unit"/>
+          <prop v="0" k="dash_pattern_offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
+          <prop v="MM" k="dash_pattern_offset_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="197,197,197,128" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="1" k="line_width"/>
+          <prop v="MM" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="trim_distance_end"/>
+          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
+          <prop v="MM" k="trim_distance_end_unit"/>
+          <prop v="0" k="trim_distance_start"/>
+          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
+          <prop v="MM" k="trim_distance_start_unit"/>
+          <prop v="0" k="tweak_dash_pattern_on_corners"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+    <source-symbol>
+      <symbol alpha="1" force_rhr="0" clip_to_extent="1" type="line" name="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleLine" pass="0" enabled="1" locked="0">
+          <Option type="Map">
+            <Option value="0" type="QString" name="align_dash_pattern"/>
+            <Option value="square" type="QString" name="capstyle"/>
+            <Option value="5;2" type="QString" name="customdash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
+            <Option value="MM" type="QString" name="customdash_unit"/>
+            <Option value="0" type="QString" name="dash_pattern_offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
+            <Option value="0" type="QString" name="draw_inside_polygon"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="213,180,60,255" type="QString" name="line_color"/>
+            <Option value="solid" type="QString" name="line_style"/>
+            <Option value="1" type="QString" name="line_width"/>
+            <Option value="MM" type="QString" name="line_width_unit"/>
+            <Option value="0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0" type="QString" name="ring_filter"/>
+            <Option value="0" type="QString" name="trim_distance_end"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
+            <Option value="0" type="QString" name="trim_distance_start"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
+            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
+            <Option value="0" type="QString" name="use_custom_dash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
+          </Option>
+          <prop v="0" k="align_dash_pattern"/>
+          <prop v="square" k="capstyle"/>
+          <prop v="5;2" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="MM" k="customdash_unit"/>
+          <prop v="0" k="dash_pattern_offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
+          <prop v="MM" k="dash_pattern_offset_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="213,180,60,255" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="1" k="line_width"/>
+          <prop v="MM" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="trim_distance_end"/>
+          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
+          <prop v="MM" k="trim_distance_end_unit"/>
+          <prop v="0" k="trim_distance_start"/>
+          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
+          <prop v="MM" k="trim_distance_start_unit"/>
+          <prop v="0" k="tweak_dash_pattern_on_corners"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </source-symbol>
+    <rotation/>
+    <sizescale/>
+  </renderer-v2>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerGeometryType>1</layerGeometryType>
+</qgis>"""
+
+STYLING_POLYGONS_THREEDI = """
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.22.4-Białowieża" styleCategories="Symbology">
+  <renderer-v2 symbollevels="0" forceraster="0" enableorderby="0" type="categorizedSymbol" attr="in_both" referencescale="-1">
+    <categories>
+      <category symbol="0" render="true" label="Damo" value="damo"/>
+      <category symbol="1" render="true" label="Model" value="model"/>
+      <category symbol="2" render="true" label="Both" value="bot"/>
+    </categories>
+    <symbols>
+      <symbol alpha="1" force_rhr="0" clip_to_extent="1" type="fill" name="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleFill" pass="0" enabled="1" locked="0">
+          <Option type="Map">
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="255,127,0,255" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="35,35,35,255" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.26" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
+          </Option>
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="255,127,0,255" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.26" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol alpha="1" force_rhr="0" clip_to_extent="1" type="fill" name="1">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleFill" pass="0" enabled="1" locked="0">
+          <Option type="Map">
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="62,131,249,255" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="35,35,35,255" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.26" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
+          </Option>
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="62,131,249,255" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.26" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol alpha="1" force_rhr="0" clip_to_extent="1" type="fill" name="2">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleFill" pass="0" enabled="1" locked="0">
+          <Option type="Map">
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="197,197,197,128" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="35,35,35,255" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.26" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
+          </Option>
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="197,197,197,128" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.26" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+    <source-symbol>
+      <symbol alpha="1" force_rhr="0" clip_to_extent="1" type="fill" name="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleFill" pass="0" enabled="1" locked="0">
+          <Option type="Map">
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="141,90,153,255" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="35,35,35,255" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.26" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
+          </Option>
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="141,90,153,255" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.26" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </source-symbol>
+    <rotation/>
+    <sizescale/>
+  </renderer-v2>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerGeometryType>2</layerGeometryType>
+</qgis>
+"""

--- a/hhnk_threedi_tools/core/vergelijkingstool/styling.py
+++ b/hhnk_threedi_tools/core/vergelijkingstool/styling.py
@@ -1,4 +1,18 @@
-STYLING_BASIC_TABLE_COLUMNS = ['id', 'f_table_catalog', 'f_table_schema', 'f_table_name', 'f_geometry_column', 'styleName', 'styleQML', 'styleSLD', 'useAsDefault', 'description', 'owner', 'ui', 'update_time']
+STYLING_BASIC_TABLE_COLUMNS = [
+    "id",
+    "f_table_catalog",
+    "f_table_schema",
+    "f_table_name",
+    "f_geometry_column",
+    "styleName",
+    "styleQML",
+    "styleSLD",
+    "useAsDefault",
+    "description",
+    "owner",
+    "ui",
+    "update_time",
+]
 
 STYLING_POINTS_DAMO = r"""
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>

--- a/hhnk_threedi_tools/core/vergelijkingstool/styling/KDU.qml
+++ b/hhnk_threedi_tools/core/vergelijkingstool/styling/KDU.qml
@@ -1,0 +1,1622 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis hasScaleBasedVisibilityFlag="0" styleCategories="AllStyleCategories" maxScale="0" readOnly="0" minScale="0" version="3.26.1-Buenos Aires" simplifyLocal="1" simplifyDrawingTol="1" symbologyReferenceScale="-1" simplifyDrawingHints="1" labelsEnabled="0" simplifyAlgorithm="0" simplifyMaxScale="1">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+    <Private>0</Private>
+  </flags>
+  <temporal endField="" accumulate="0" mode="0" startField="" durationField="" limitMode="0" startExpression="" enabled="0" fixedDuration="0" endExpression="" durationUnit="min">
+    <fixedRange>
+      <start></start>
+      <end></end>
+    </fixedRange>
+  </temporal>
+  <elevation binding="Centroid" extrusionEnabled="0" type="IndividualFeatures" zoffset="0" extrusion="0" symbology="Line" showMarkerSymbolInSurfacePlots="0" clamping="Terrain" zscale="1" respectLayerSymbol="1">
+    <data-defined-properties>
+      <Option type="Map">
+        <Option type="QString" name="name" value=""/>
+        <Option name="properties"/>
+        <Option type="QString" name="type" value="collection"/>
+      </Option>
+    </data-defined-properties>
+    <profileLineSymbol>
+      <symbol type="line" frame_rate="10" clip_to_extent="1" name="" force_rhr="0" alpha="1" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" name="name" value=""/>
+            <Option name="properties"/>
+            <Option type="QString" name="type" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option type="QString" name="align_dash_pattern" value="0"/>
+            <Option type="QString" name="capstyle" value="square"/>
+            <Option type="QString" name="customdash" value="5;2"/>
+            <Option type="QString" name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="customdash_unit" value="MM"/>
+            <Option type="QString" name="dash_pattern_offset" value="0"/>
+            <Option type="QString" name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="dash_pattern_offset_unit" value="MM"/>
+            <Option type="QString" name="draw_inside_polygon" value="0"/>
+            <Option type="QString" name="joinstyle" value="bevel"/>
+            <Option type="QString" name="line_color" value="125,139,143,255"/>
+            <Option type="QString" name="line_style" value="solid"/>
+            <Option type="QString" name="line_width" value="0.6"/>
+            <Option type="QString" name="line_width_unit" value="MM"/>
+            <Option type="QString" name="offset" value="0"/>
+            <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="offset_unit" value="MM"/>
+            <Option type="QString" name="ring_filter" value="0"/>
+            <Option type="QString" name="trim_distance_end" value="0"/>
+            <Option type="QString" name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="trim_distance_end_unit" value="MM"/>
+            <Option type="QString" name="trim_distance_start" value="0"/>
+            <Option type="QString" name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="trim_distance_start_unit" value="MM"/>
+            <Option type="QString" name="tweak_dash_pattern_on_corners" value="0"/>
+            <Option type="QString" name="use_custom_dash" value="0"/>
+            <Option type="QString" name="width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+          </Option>
+          <prop k="align_dash_pattern" v="0"/>
+          <prop k="capstyle" v="square"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="dash_pattern_offset" v="0"/>
+          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="dash_pattern_offset_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="125,139,143,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="0.6"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="trim_distance_end" v="0"/>
+          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_end_unit" v="MM"/>
+          <prop k="trim_distance_start" v="0"/>
+          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_start_unit" v="MM"/>
+          <prop k="tweak_dash_pattern_on_corners" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" name="name" value=""/>
+              <Option name="properties"/>
+              <Option type="QString" name="type" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </profileLineSymbol>
+    <profileFillSymbol>
+      <symbol type="fill" frame_rate="10" clip_to_extent="1" name="" force_rhr="0" alpha="1" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" name="name" value=""/>
+            <Option name="properties"/>
+            <Option type="QString" name="type" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleFill" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option type="QString" name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="color" value="125,139,143,255"/>
+            <Option type="QString" name="joinstyle" value="bevel"/>
+            <Option type="QString" name="offset" value="0,0"/>
+            <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="offset_unit" value="MM"/>
+            <Option type="QString" name="outline_color" value="89,99,102,255"/>
+            <Option type="QString" name="outline_style" value="solid"/>
+            <Option type="QString" name="outline_width" value="0.2"/>
+            <Option type="QString" name="outline_width_unit" value="MM"/>
+            <Option type="QString" name="style" value="solid"/>
+          </Option>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="125,139,143,255"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="89,99,102,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.2"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" name="name" value=""/>
+              <Option name="properties"/>
+              <Option type="QString" name="type" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </profileFillSymbol>
+    <profileMarkerSymbol>
+      <symbol type="marker" frame_rate="10" clip_to_extent="1" name="" force_rhr="0" alpha="1" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" name="name" value=""/>
+            <Option name="properties"/>
+            <Option type="QString" name="type" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option type="QString" name="angle" value="0"/>
+            <Option type="QString" name="cap_style" value="square"/>
+            <Option type="QString" name="color" value="125,139,143,255"/>
+            <Option type="QString" name="horizontal_anchor_point" value="1"/>
+            <Option type="QString" name="joinstyle" value="bevel"/>
+            <Option type="QString" name="name" value="diamond"/>
+            <Option type="QString" name="offset" value="0,0"/>
+            <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="offset_unit" value="MM"/>
+            <Option type="QString" name="outline_color" value="89,99,102,255"/>
+            <Option type="QString" name="outline_style" value="solid"/>
+            <Option type="QString" name="outline_width" value="0.2"/>
+            <Option type="QString" name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="outline_width_unit" value="MM"/>
+            <Option type="QString" name="scale_method" value="diameter"/>
+            <Option type="QString" name="size" value="3"/>
+            <Option type="QString" name="size_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="size_unit" value="MM"/>
+            <Option type="QString" name="vertical_anchor_point" value="1"/>
+          </Option>
+          <prop k="angle" v="0"/>
+          <prop k="cap_style" v="square"/>
+          <prop k="color" v="125,139,143,255"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="name" v="diamond"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="89,99,102,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.2"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="scale_method" v="diameter"/>
+          <prop k="size" v="3"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" name="name" value=""/>
+              <Option name="properties"/>
+              <Option type="QString" name="type" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </profileMarkerSymbol>
+  </elevation>
+  <renderer-v2 type="categorizedSymbol" referencescale="-1" attr="in_both" symbollevels="0" enableorderby="0" forceraster="0">
+    <categories>
+      <category type="string" render="true" value="castricum damo" symbol="0" label="Damo castricum Mon Jun 16 14:37:16 2025"/>
+      <category type="string" render="true" value="castricum sqlite" symbol="1" label="Model castricum Mon Jun 16 14:37:20 2025"/>/>
+      <category type="string" render="true" value="castricum both" symbol="2" label="castricum both"/>
+    </categories>
+    <symbols>
+      <symbol type="line" frame_rate="10" clip_to_extent="1" name="0" force_rhr="0" alpha="1" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" name="name" value=""/>
+            <Option name="properties"/>
+            <Option type="QString" name="type" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option type="QString" name="align_dash_pattern" value="0"/>
+            <Option type="QString" name="capstyle" value="round"/>
+            <Option type="QString" name="customdash" value="0.66;2"/>
+            <Option type="QString" name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="customdash_unit" value="MM"/>
+            <Option type="QString" name="dash_pattern_offset" value="0"/>
+            <Option type="QString" name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="dash_pattern_offset_unit" value="MM"/>
+            <Option type="QString" name="draw_inside_polygon" value="0"/>
+            <Option type="QString" name="joinstyle" value="round"/>
+            <Option type="QString" name="line_color" value="219,30,42,255"/>
+            <Option type="QString" name="line_style" value="solid"/>
+            <Option type="QString" name="line_width" value="0.66"/>
+            <Option type="QString" name="line_width_unit" value="MM"/>
+            <Option type="QString" name="offset" value="0"/>
+            <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="offset_unit" value="MM"/>
+            <Option type="QString" name="ring_filter" value="0"/>
+            <Option type="QString" name="trim_distance_end" value="0"/>
+            <Option type="QString" name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="trim_distance_end_unit" value="MM"/>
+            <Option type="QString" name="trim_distance_start" value="0"/>
+            <Option type="QString" name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="trim_distance_start_unit" value="MM"/>
+            <Option type="QString" name="tweak_dash_pattern_on_corners" value="0"/>
+            <Option type="QString" name="use_custom_dash" value="1"/>
+            <Option type="QString" name="width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+          </Option>
+          <prop k="align_dash_pattern" v="0"/>
+          <prop k="capstyle" v="round"/>
+          <prop k="customdash" v="0.66;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="dash_pattern_offset" v="0"/>
+          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="dash_pattern_offset_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="round"/>
+          <prop k="line_color" v="219,30,42,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="0.66"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="trim_distance_end" v="0"/>
+          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_end_unit" v="MM"/>
+          <prop k="trim_distance_start" v="0"/>
+          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_start_unit" v="MM"/>
+          <prop k="tweak_dash_pattern_on_corners" v="0"/>
+          <prop k="use_custom_dash" v="1"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" name="name" value=""/>
+              <Option name="properties"/>
+              <Option type="QString" name="type" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol type="line" frame_rate="10" clip_to_extent="1" name="1" force_rhr="0" alpha="1" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" name="name" value=""/>
+            <Option name="properties"/>
+            <Option type="QString" name="type" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option type="QString" name="align_dash_pattern" value="0"/>
+            <Option type="QString" name="capstyle" value="square"/>
+            <Option type="QString" name="customdash" value="5;2"/>
+            <Option type="QString" name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="customdash_unit" value="MM"/>
+            <Option type="QString" name="dash_pattern_offset" value="0"/>
+            <Option type="QString" name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="dash_pattern_offset_unit" value="MM"/>
+            <Option type="QString" name="draw_inside_polygon" value="0"/>
+            <Option type="QString" name="joinstyle" value="bevel"/>
+            <Option type="QString" name="line_color" value="149,74,162,255"/>
+            <Option type="QString" name="line_style" value="solid"/>
+            <Option type="QString" name="line_width" value="0.66"/>
+            <Option type="QString" name="line_width_unit" value="MM"/>
+            <Option type="QString" name="offset" value="0"/>
+            <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="offset_unit" value="MM"/>
+            <Option type="QString" name="ring_filter" value="0"/>
+            <Option type="QString" name="trim_distance_end" value="0"/>
+            <Option type="QString" name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="trim_distance_end_unit" value="MM"/>
+            <Option type="QString" name="trim_distance_start" value="0"/>
+            <Option type="QString" name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="trim_distance_start_unit" value="MM"/>
+            <Option type="QString" name="tweak_dash_pattern_on_corners" value="0"/>
+            <Option type="QString" name="use_custom_dash" value="0"/>
+            <Option type="QString" name="width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+          </Option>
+          <prop k="align_dash_pattern" v="0"/>
+          <prop k="capstyle" v="square"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="dash_pattern_offset" v="0"/>
+          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="dash_pattern_offset_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="149,74,162,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="0.66"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="trim_distance_end" v="0"/>
+          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_end_unit" v="MM"/>
+          <prop k="trim_distance_start" v="0"/>
+          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_start_unit" v="MM"/>
+          <prop k="tweak_dash_pattern_on_corners" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" name="name" value=""/>
+              <Option name="properties"/>
+              <Option type="QString" name="type" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol type="line" frame_rate="10" clip_to_extent="1" name="2" force_rhr="0" alpha="1" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" name="name" value=""/>
+            <Option name="properties"/>
+            <Option type="QString" name="type" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option type="QString" name="align_dash_pattern" value="0"/>
+            <Option type="QString" name="capstyle" value="square"/>
+            <Option type="QString" name="customdash" value="5;2"/>
+            <Option type="QString" name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="customdash_unit" value="MM"/>
+            <Option type="QString" name="dash_pattern_offset" value="0"/>
+            <Option type="QString" name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="dash_pattern_offset_unit" value="MM"/>
+            <Option type="QString" name="draw_inside_polygon" value="0"/>
+            <Option type="QString" name="joinstyle" value="bevel"/>
+            <Option type="QString" name="line_color" value="197,197,197,0"/>
+            <Option type="QString" name="line_style" value="solid"/>
+            <Option type="QString" name="line_width" value="1"/>
+            <Option type="QString" name="line_width_unit" value="MM"/>
+            <Option type="QString" name="offset" value="0"/>
+            <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="offset_unit" value="MM"/>
+            <Option type="QString" name="ring_filter" value="0"/>
+            <Option type="QString" name="trim_distance_end" value="0"/>
+            <Option type="QString" name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="trim_distance_end_unit" value="MM"/>
+            <Option type="QString" name="trim_distance_start" value="0"/>
+            <Option type="QString" name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="trim_distance_start_unit" value="MM"/>
+            <Option type="QString" name="tweak_dash_pattern_on_corners" value="0"/>
+            <Option type="QString" name="use_custom_dash" value="0"/>
+            <Option type="QString" name="width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+          </Option>
+          <prop k="align_dash_pattern" v="0"/>
+          <prop k="capstyle" v="square"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="dash_pattern_offset" v="0"/>
+          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="dash_pattern_offset_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="197,197,197,0"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="1"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="trim_distance_end" v="0"/>
+          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_end_unit" v="MM"/>
+          <prop k="trim_distance_start" v="0"/>
+          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_start_unit" v="MM"/>
+          <prop k="tweak_dash_pattern_on_corners" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" name="name" value=""/>
+              <Option name="properties"/>
+              <Option type="QString" name="type" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+    <source-symbol>
+      <symbol type="line" frame_rate="10" clip_to_extent="1" name="0" force_rhr="0" alpha="1" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" name="name" value=""/>
+            <Option name="properties"/>
+            <Option type="QString" name="type" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleLine" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option type="QString" name="align_dash_pattern" value="0"/>
+            <Option type="QString" name="capstyle" value="square"/>
+            <Option type="QString" name="customdash" value="5;2"/>
+            <Option type="QString" name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="customdash_unit" value="MM"/>
+            <Option type="QString" name="dash_pattern_offset" value="0"/>
+            <Option type="QString" name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="dash_pattern_offset_unit" value="MM"/>
+            <Option type="QString" name="draw_inside_polygon" value="0"/>
+            <Option type="QString" name="joinstyle" value="bevel"/>
+            <Option type="QString" name="line_color" value="213,180,60,255"/>
+            <Option type="QString" name="line_style" value="solid"/>
+            <Option type="QString" name="line_width" value="1"/>
+            <Option type="QString" name="line_width_unit" value="MM"/>
+            <Option type="QString" name="offset" value="0"/>
+            <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="offset_unit" value="MM"/>
+            <Option type="QString" name="ring_filter" value="0"/>
+            <Option type="QString" name="trim_distance_end" value="0"/>
+            <Option type="QString" name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="trim_distance_end_unit" value="MM"/>
+            <Option type="QString" name="trim_distance_start" value="0"/>
+            <Option type="QString" name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="trim_distance_start_unit" value="MM"/>
+            <Option type="QString" name="tweak_dash_pattern_on_corners" value="0"/>
+            <Option type="QString" name="use_custom_dash" value="0"/>
+            <Option type="QString" name="width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+          </Option>
+          <prop k="align_dash_pattern" v="0"/>
+          <prop k="capstyle" v="square"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="dash_pattern_offset" v="0"/>
+          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="dash_pattern_offset_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="213,180,60,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="1"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="trim_distance_end" v="0"/>
+          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_end_unit" v="MM"/>
+          <prop k="trim_distance_start" v="0"/>
+          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_start_unit" v="MM"/>
+          <prop k="tweak_dash_pattern_on_corners" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" name="name" value=""/>
+              <Option name="properties"/>
+              <Option type="QString" name="type" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </source-symbol>
+    <rotation/>
+    <sizescale/>
+  </renderer-v2>
+  <customproperties>
+    <Option type="Map">
+      <Option type="int" name="embeddedWidgets/count" value="0"/>
+      <Option name="variableNames"/>
+      <Option name="variableValues"/>
+    </Option>
+  </customproperties>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+    <DiagramCategory maxScaleDenominator="0" minScaleDenominator="0" penColor="#000000" opacity="1" labelPlacementMethod="XHeight" enabled="0" penAlpha="255" spacingUnitScale="3x:0,0,0,0,0,0" width="15" direction="0" lineSizeScale="3x:0,0,0,0,0,0" spacing="5" barWidth="5" spacingUnit="MM" sizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" backgroundColor="#ffffff" scaleDependency="Area" showAxis="1" penWidth="0" scaleBasedVisibility="0" rotationOffset="270" sizeType="MM" height="15" minimumSize="0" lineSizeType="MM" backgroundAlpha="255">
+      <fontProperties italic="0" description="MS Shell Dlg 2,7.8,-1,5,50,0,0,0,0,0" strikethrough="0" underline="0" bold="0" style=""/>
+      <axisSymbol>
+        <symbol type="line" frame_rate="10" clip_to_extent="1" name="" force_rhr="0" alpha="1" is_animated="0">
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" name="name" value=""/>
+              <Option name="properties"/>
+              <Option type="QString" name="type" value="collection"/>
+            </Option>
+          </data_defined_properties>
+          <layer class="SimpleLine" pass="0" locked="0" enabled="1">
+            <Option type="Map">
+              <Option type="QString" name="align_dash_pattern" value="0"/>
+              <Option type="QString" name="capstyle" value="square"/>
+              <Option type="QString" name="customdash" value="5;2"/>
+              <Option type="QString" name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+              <Option type="QString" name="customdash_unit" value="MM"/>
+              <Option type="QString" name="dash_pattern_offset" value="0"/>
+              <Option type="QString" name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+              <Option type="QString" name="dash_pattern_offset_unit" value="MM"/>
+              <Option type="QString" name="draw_inside_polygon" value="0"/>
+              <Option type="QString" name="joinstyle" value="bevel"/>
+              <Option type="QString" name="line_color" value="35,35,35,255"/>
+              <Option type="QString" name="line_style" value="solid"/>
+              <Option type="QString" name="line_width" value="0.26"/>
+              <Option type="QString" name="line_width_unit" value="MM"/>
+              <Option type="QString" name="offset" value="0"/>
+              <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+              <Option type="QString" name="offset_unit" value="MM"/>
+              <Option type="QString" name="ring_filter" value="0"/>
+              <Option type="QString" name="trim_distance_end" value="0"/>
+              <Option type="QString" name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+              <Option type="QString" name="trim_distance_end_unit" value="MM"/>
+              <Option type="QString" name="trim_distance_start" value="0"/>
+              <Option type="QString" name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+              <Option type="QString" name="trim_distance_start_unit" value="MM"/>
+              <Option type="QString" name="tweak_dash_pattern_on_corners" value="0"/>
+              <Option type="QString" name="use_custom_dash" value="0"/>
+              <Option type="QString" name="width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            </Option>
+            <prop k="align_dash_pattern" v="0"/>
+            <prop k="capstyle" v="square"/>
+            <prop k="customdash" v="5;2"/>
+            <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="customdash_unit" v="MM"/>
+            <prop k="dash_pattern_offset" v="0"/>
+            <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="dash_pattern_offset_unit" v="MM"/>
+            <prop k="draw_inside_polygon" v="0"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="line_color" v="35,35,35,255"/>
+            <prop k="line_style" v="solid"/>
+            <prop k="line_width" v="0.26"/>
+            <prop k="line_width_unit" v="MM"/>
+            <prop k="offset" v="0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="ring_filter" v="0"/>
+            <prop k="trim_distance_end" v="0"/>
+            <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="trim_distance_end_unit" v="MM"/>
+            <prop k="trim_distance_start" v="0"/>
+            <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="trim_distance_start_unit" v="MM"/>
+            <prop k="tweak_dash_pattern_on_corners" v="0"/>
+            <prop k="use_custom_dash" v="0"/>
+            <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" name="name" value=""/>
+                <Option name="properties"/>
+                <Option type="QString" name="type" value="collection"/>
+              </Option>
+            </data_defined_properties>
+          </layer>
+        </symbol>
+      </axisSymbol>
+    </DiagramCategory>
+  </SingleCategoryDiagramRenderer>
+  <DiagramLayerSettings linePlacementFlags="18" dist="0" priority="0" placement="2" obstacle="0" showAll="1" zIndex="0">
+    <properties>
+      <Option type="Map">
+        <Option type="QString" name="name" value=""/>
+        <Option name="properties"/>
+        <Option type="QString" name="type" value="collection"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <legend type="default-vector" showLabelLegend="0"/>
+  <referencedLayers/>
+  <fieldConfiguration>
+    <field name="fid" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="level_0" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="level_1" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="id_model" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="display_name_model" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="code" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="calculation_type_model" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="friction_value_model" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="friction_type_model" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="dist_calc_points_model" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="zoom_category_model" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="discharge_coefficient_positive_model" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="discharge_coefficient_negative_model" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="invert_level_start_point_model" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="invert_level_end_point_model" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="connection_node_start_id_model" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="connection_node_end_id_model" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cross_section_definition_id_model" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="wkt_geom_model" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cross_section_max_width_model" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cross_section_max_height_model" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="origin_model" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="crest_type_model" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="crest_level_model" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="sewerage_model" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="id_start_model" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="id_end_model" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="geom_type_model" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="geom_length_model" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="geom_area_model" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="dataset_model" configurationFlags="None">
+      <editWidget type="CheckBox">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="naam_damo" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="opmerking_damo" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="indicatiewaterkerend_damo" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="indpeilregulpeilscheidend_damo" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="lengte_damo" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="hoogteopening_damo" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="breedteopening_damo" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="hoogtebinnenonderkantbene_damo" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="hoogtebinnenonderkantbov_damo" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="vormkoker_damo" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="soortmateriaal_damo" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="typekruising_damo" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="ws_categorie_damo" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="ws_bron_damo" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="ws_inwinningswijze_damo" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="ws_inwinningsdatum_damo" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="ws_inlaatfunctie_damo" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="ws_afsluitwijze1_damo" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="ws_afsluitwijze2_damo" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="shape_length_damo" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="geom_type_damo" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="geom_length_damo" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="geom_area_damo" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="dataset_damo" configurationFlags="None">
+      <editWidget type="CheckBox">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="origin_damo" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="in_both" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cmp_bob_bov" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cmp_bob_bov_change_NaN" configurationFlags="None">
+      <editWidget type="CheckBox">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cmp_bob_bovpriority" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cmp_bob_max" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cmp_bob_max_change_NaN" configurationFlags="None">
+      <editWidget type="CheckBox">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="cmp_bob_maxpriority" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias field="fid" name="" index="0"/>
+    <alias field="level_0" name="" index="1"/>
+    <alias field="level_1" name="" index="2"/>
+    <alias field="id_model" name="" index="3"/>
+    <alias field="display_name_model" name="" index="4"/>
+    <alias field="code" name="" index="5"/>
+    <alias field="calculation_type_model" name="" index="6"/>
+    <alias field="friction_value_model" name="" index="7"/>
+    <alias field="friction_type_model" name="" index="8"/>
+    <alias field="dist_calc_points_model" name="" index="9"/>
+    <alias field="zoom_category_model" name="" index="10"/>
+    <alias field="discharge_coefficient_positive_model" name="" index="11"/>
+    <alias field="discharge_coefficient_negative_model" name="" index="12"/>
+    <alias field="invert_level_start_point_model" name="" index="13"/>
+    <alias field="invert_level_end_point_model" name="" index="14"/>
+    <alias field="connection_node_start_id_model" name="" index="15"/>
+    <alias field="connection_node_end_id_model" name="" index="16"/>
+    <alias field="cross_section_definition_id_model" name="" index="17"/>
+    <alias field="wkt_geom_model" name="" index="18"/>
+    <alias field="cross_section_max_width_model" name="" index="19"/>
+    <alias field="cross_section_max_height_model" name="" index="20"/>
+    <alias field="origin_model" name="" index="21"/>
+    <alias field="crest_type_model" name="" index="22"/>
+    <alias field="crest_level_model" name="" index="23"/>
+    <alias field="sewerage_model" name="" index="24"/>
+    <alias field="id_start_model" name="" index="25"/>
+    <alias field="id_end_model" name="" index="26"/>
+    <alias field="geom_type_model" name="" index="27"/>
+    <alias field="geom_length_model" name="" index="28"/>
+    <alias field="geom_area_model" name="" index="29"/>
+    <alias field="dataset_model" name="" index="30"/>
+    <alias field="naam_damo" name="" index="31"/>
+    <alias field="opmerking_damo" name="" index="32"/>
+    <alias field="indicatiewaterkerend_damo" name="" index="33"/>
+    <alias field="indpeilregulpeilscheidend_damo" name="" index="34"/>
+    <alias field="lengte_damo" name="" index="35"/>
+    <alias field="hoogteopening_damo" name="" index="36"/>
+    <alias field="breedteopening_damo" name="" index="37"/>
+    <alias field="hoogtebinnenonderkantbene_damo" name="" index="38"/>
+    <alias field="hoogtebinnenonderkantbov_damo" name="" index="39"/>
+    <alias field="vormkoker_damo" name="" index="40"/>
+    <alias field="soortmateriaal_damo" name="" index="41"/>
+    <alias field="typekruising_damo" name="" index="42"/>
+    <alias field="ws_categorie_damo" name="" index="43"/>
+    <alias field="ws_bron_damo" name="" index="44"/>
+    <alias field="ws_inwinningswijze_damo" name="" index="45"/>
+    <alias field="ws_inwinningsdatum_damo" name="" index="46"/>
+    <alias field="ws_inlaatfunctie_damo" name="" index="47"/>
+    <alias field="ws_afsluitwijze1_damo" name="" index="48"/>
+    <alias field="ws_afsluitwijze2_damo" name="" index="49"/>
+    <alias field="shape_length_damo" name="" index="50"/>
+    <alias field="geom_type_damo" name="" index="51"/>
+    <alias field="geom_length_damo" name="" index="52"/>
+    <alias field="geom_area_damo" name="" index="53"/>
+    <alias field="dataset_damo" name="" index="54"/>
+    <alias field="origin_damo" name="" index="55"/>
+    <alias field="in_both" name="" index="56"/>
+    <alias field="cmp_bob_bov" name="" index="57"/>
+    <alias field="cmp_bob_bov_change_NaN" name="" index="58"/>
+    <alias field="cmp_bob_bovpriority" name="" index="59"/>
+    <alias field="cmp_bob_max" name="" index="60"/>
+    <alias field="cmp_bob_max_change_NaN" name="" index="61"/>
+    <alias field="cmp_bob_maxpriority" name="" index="62"/>
+  </aliases>
+  <defaults>
+    <default field="fid" applyOnUpdate="0" expression=""/>
+    <default field="level_0" applyOnUpdate="0" expression=""/>
+    <default field="level_1" applyOnUpdate="0" expression=""/>
+    <default field="id_model" applyOnUpdate="0" expression=""/>
+    <default field="display_name_model" applyOnUpdate="0" expression=""/>
+    <default field="code" applyOnUpdate="0" expression=""/>
+    <default field="calculation_type_model" applyOnUpdate="0" expression=""/>
+    <default field="friction_value_model" applyOnUpdate="0" expression=""/>
+    <default field="friction_type_model" applyOnUpdate="0" expression=""/>
+    <default field="dist_calc_points_model" applyOnUpdate="0" expression=""/>
+    <default field="zoom_category_model" applyOnUpdate="0" expression=""/>
+    <default field="discharge_coefficient_positive_model" applyOnUpdate="0" expression=""/>
+    <default field="discharge_coefficient_negative_model" applyOnUpdate="0" expression=""/>
+    <default field="invert_level_start_point_model" applyOnUpdate="0" expression=""/>
+    <default field="invert_level_end_point_model" applyOnUpdate="0" expression=""/>
+    <default field="connection_node_start_id_model" applyOnUpdate="0" expression=""/>
+    <default field="connection_node_end_id_model" applyOnUpdate="0" expression=""/>
+    <default field="cross_section_definition_id_model" applyOnUpdate="0" expression=""/>
+    <default field="wkt_geom_model" applyOnUpdate="0" expression=""/>
+    <default field="cross_section_max_width_model" applyOnUpdate="0" expression=""/>
+    <default field="cross_section_max_height_model" applyOnUpdate="0" expression=""/>
+    <default field="origin_model" applyOnUpdate="0" expression=""/>
+    <default field="crest_type_model" applyOnUpdate="0" expression=""/>
+    <default field="crest_level_model" applyOnUpdate="0" expression=""/>
+    <default field="sewerage_model" applyOnUpdate="0" expression=""/>
+    <default field="id_start_model" applyOnUpdate="0" expression=""/>
+    <default field="id_end_model" applyOnUpdate="0" expression=""/>
+    <default field="geom_type_model" applyOnUpdate="0" expression=""/>
+    <default field="geom_length_model" applyOnUpdate="0" expression=""/>
+    <default field="geom_area_model" applyOnUpdate="0" expression=""/>
+    <default field="dataset_model" applyOnUpdate="0" expression=""/>
+    <default field="naam_damo" applyOnUpdate="0" expression=""/>
+    <default field="opmerking_damo" applyOnUpdate="0" expression=""/>
+    <default field="indicatiewaterkerend_damo" applyOnUpdate="0" expression=""/>
+    <default field="indpeilregulpeilscheidend_damo" applyOnUpdate="0" expression=""/>
+    <default field="lengte_damo" applyOnUpdate="0" expression=""/>
+    <default field="hoogteopening_damo" applyOnUpdate="0" expression=""/>
+    <default field="breedteopening_damo" applyOnUpdate="0" expression=""/>
+    <default field="hoogtebinnenonderkantbene_damo" applyOnUpdate="0" expression=""/>
+    <default field="hoogtebinnenonderkantbov_damo" applyOnUpdate="0" expression=""/>
+    <default field="vormkoker_damo" applyOnUpdate="0" expression=""/>
+    <default field="soortmateriaal_damo" applyOnUpdate="0" expression=""/>
+    <default field="typekruising_damo" applyOnUpdate="0" expression=""/>
+    <default field="ws_categorie_damo" applyOnUpdate="0" expression=""/>
+    <default field="ws_bron_damo" applyOnUpdate="0" expression=""/>
+    <default field="ws_inwinningswijze_damo" applyOnUpdate="0" expression=""/>
+    <default field="ws_inwinningsdatum_damo" applyOnUpdate="0" expression=""/>
+    <default field="ws_inlaatfunctie_damo" applyOnUpdate="0" expression=""/>
+    <default field="ws_afsluitwijze1_damo" applyOnUpdate="0" expression=""/>
+    <default field="ws_afsluitwijze2_damo" applyOnUpdate="0" expression=""/>
+    <default field="shape_length_damo" applyOnUpdate="0" expression=""/>
+    <default field="geom_type_damo" applyOnUpdate="0" expression=""/>
+    <default field="geom_length_damo" applyOnUpdate="0" expression=""/>
+    <default field="geom_area_damo" applyOnUpdate="0" expression=""/>
+    <default field="dataset_damo" applyOnUpdate="0" expression=""/>
+    <default field="origin_damo" applyOnUpdate="0" expression=""/>
+    <default field="in_both" applyOnUpdate="0" expression=""/>
+    <default field="cmp_bob_bov" applyOnUpdate="0" expression=""/>
+    <default field="cmp_bob_bov_change_NaN" applyOnUpdate="0" expression=""/>
+    <default field="cmp_bob_bovpriority" applyOnUpdate="0" expression=""/>
+    <default field="cmp_bob_max" applyOnUpdate="0" expression=""/>
+    <default field="cmp_bob_max_change_NaN" applyOnUpdate="0" expression=""/>
+    <default field="cmp_bob_maxpriority" applyOnUpdate="0" expression=""/>
+  </defaults>
+  <constraints>
+    <constraint constraints="3" unique_strength="1" field="fid" notnull_strength="1" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="level_0" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="level_1" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="id_model" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="display_name_model" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="code" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="calculation_type_model" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="friction_value_model" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="friction_type_model" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="dist_calc_points_model" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="zoom_category_model" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="discharge_coefficient_positive_model" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="discharge_coefficient_negative_model" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="invert_level_start_point_model" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="invert_level_end_point_model" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="connection_node_start_id_model" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="connection_node_end_id_model" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="cross_section_definition_id_model" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="wkt_geom_model" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="cross_section_max_width_model" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="cross_section_max_height_model" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="origin_model" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="crest_type_model" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="crest_level_model" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="sewerage_model" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="id_start_model" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="id_end_model" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="geom_type_model" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="geom_length_model" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="geom_area_model" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="dataset_model" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="naam_damo" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="opmerking_damo" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="indicatiewaterkerend_damo" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="indpeilregulpeilscheidend_damo" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="lengte_damo" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="hoogteopening_damo" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="breedteopening_damo" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="hoogtebinnenonderkantbene_damo" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="hoogtebinnenonderkantbov_damo" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="vormkoker_damo" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="soortmateriaal_damo" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="typekruising_damo" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="ws_categorie_damo" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="ws_bron_damo" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="ws_inwinningswijze_damo" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="ws_inwinningsdatum_damo" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="ws_inlaatfunctie_damo" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="ws_afsluitwijze1_damo" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="ws_afsluitwijze2_damo" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="shape_length_damo" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="geom_type_damo" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="geom_length_damo" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="geom_area_damo" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="dataset_damo" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="origin_damo" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="in_both" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="cmp_bob_bov" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="cmp_bob_bov_change_NaN" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="cmp_bob_bovpriority" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="cmp_bob_max" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="cmp_bob_max_change_NaN" notnull_strength="0" exp_strength="0"/>
+    <constraint constraints="0" unique_strength="0" field="cmp_bob_maxpriority" notnull_strength="0" exp_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint desc="" field="fid" exp=""/>
+    <constraint desc="" field="level_0" exp=""/>
+    <constraint desc="" field="level_1" exp=""/>
+    <constraint desc="" field="id_model" exp=""/>
+    <constraint desc="" field="display_name_model" exp=""/>
+    <constraint desc="" field="code" exp=""/>
+    <constraint desc="" field="calculation_type_model" exp=""/>
+    <constraint desc="" field="friction_value_model" exp=""/>
+    <constraint desc="" field="friction_type_model" exp=""/>
+    <constraint desc="" field="dist_calc_points_model" exp=""/>
+    <constraint desc="" field="zoom_category_model" exp=""/>
+    <constraint desc="" field="discharge_coefficient_positive_model" exp=""/>
+    <constraint desc="" field="discharge_coefficient_negative_model" exp=""/>
+    <constraint desc="" field="invert_level_start_point_model" exp=""/>
+    <constraint desc="" field="invert_level_end_point_model" exp=""/>
+    <constraint desc="" field="connection_node_start_id_model" exp=""/>
+    <constraint desc="" field="connection_node_end_id_model" exp=""/>
+    <constraint desc="" field="cross_section_definition_id_model" exp=""/>
+    <constraint desc="" field="wkt_geom_model" exp=""/>
+    <constraint desc="" field="cross_section_max_width_model" exp=""/>
+    <constraint desc="" field="cross_section_max_height_model" exp=""/>
+    <constraint desc="" field="origin_model" exp=""/>
+    <constraint desc="" field="crest_type_model" exp=""/>
+    <constraint desc="" field="crest_level_model" exp=""/>
+    <constraint desc="" field="sewerage_model" exp=""/>
+    <constraint desc="" field="id_start_model" exp=""/>
+    <constraint desc="" field="id_end_model" exp=""/>
+    <constraint desc="" field="geom_type_model" exp=""/>
+    <constraint desc="" field="geom_length_model" exp=""/>
+    <constraint desc="" field="geom_area_model" exp=""/>
+    <constraint desc="" field="dataset_model" exp=""/>
+    <constraint desc="" field="naam_damo" exp=""/>
+    <constraint desc="" field="opmerking_damo" exp=""/>
+    <constraint desc="" field="indicatiewaterkerend_damo" exp=""/>
+    <constraint desc="" field="indpeilregulpeilscheidend_damo" exp=""/>
+    <constraint desc="" field="lengte_damo" exp=""/>
+    <constraint desc="" field="hoogteopening_damo" exp=""/>
+    <constraint desc="" field="breedteopening_damo" exp=""/>
+    <constraint desc="" field="hoogtebinnenonderkantbene_damo" exp=""/>
+    <constraint desc="" field="hoogtebinnenonderkantbov_damo" exp=""/>
+    <constraint desc="" field="vormkoker_damo" exp=""/>
+    <constraint desc="" field="soortmateriaal_damo" exp=""/>
+    <constraint desc="" field="typekruising_damo" exp=""/>
+    <constraint desc="" field="ws_categorie_damo" exp=""/>
+    <constraint desc="" field="ws_bron_damo" exp=""/>
+    <constraint desc="" field="ws_inwinningswijze_damo" exp=""/>
+    <constraint desc="" field="ws_inwinningsdatum_damo" exp=""/>
+    <constraint desc="" field="ws_inlaatfunctie_damo" exp=""/>
+    <constraint desc="" field="ws_afsluitwijze1_damo" exp=""/>
+    <constraint desc="" field="ws_afsluitwijze2_damo" exp=""/>
+    <constraint desc="" field="shape_length_damo" exp=""/>
+    <constraint desc="" field="geom_type_damo" exp=""/>
+    <constraint desc="" field="geom_length_damo" exp=""/>
+    <constraint desc="" field="geom_area_damo" exp=""/>
+    <constraint desc="" field="dataset_damo" exp=""/>
+    <constraint desc="" field="origin_damo" exp=""/>
+    <constraint desc="" field="in_both" exp=""/>
+    <constraint desc="" field="cmp_bob_bov" exp=""/>
+    <constraint desc="" field="cmp_bob_bov_change_NaN" exp=""/>
+    <constraint desc="" field="cmp_bob_bovpriority" exp=""/>
+    <constraint desc="" field="cmp_bob_max" exp=""/>
+    <constraint desc="" field="cmp_bob_max_change_NaN" exp=""/>
+    <constraint desc="" field="cmp_bob_maxpriority" exp=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+  </attributeactions>
+  <attributetableconfig sortOrder="0" sortExpression="" actionWidgetStyle="dropDown">
+    <columns>
+      <column type="field" hidden="0" width="-1" name="fid"/>
+      <column type="field" hidden="0" width="-1" name="level_0"/>
+      <column type="field" hidden="0" width="-1" name="level_1"/>
+      <column type="field" hidden="0" width="-1" name="id_model"/>
+      <column type="field" hidden="0" width="-1" name="display_name_model"/>
+      <column type="field" hidden="0" width="-1" name="code"/>
+      <column type="field" hidden="0" width="-1" name="calculation_type_model"/>
+      <column type="field" hidden="0" width="-1" name="friction_value_model"/>
+      <column type="field" hidden="0" width="-1" name="friction_type_model"/>
+      <column type="field" hidden="0" width="-1" name="dist_calc_points_model"/>
+      <column type="field" hidden="0" width="-1" name="zoom_category_model"/>
+      <column type="field" hidden="0" width="-1" name="discharge_coefficient_positive_model"/>
+      <column type="field" hidden="0" width="-1" name="discharge_coefficient_negative_model"/>
+      <column type="field" hidden="0" width="-1" name="invert_level_start_point_model"/>
+      <column type="field" hidden="0" width="-1" name="invert_level_end_point_model"/>
+      <column type="field" hidden="0" width="-1" name="connection_node_start_id_model"/>
+      <column type="field" hidden="0" width="-1" name="connection_node_end_id_model"/>
+      <column type="field" hidden="0" width="-1" name="cross_section_definition_id_model"/>
+      <column type="field" hidden="0" width="-1" name="wkt_geom_model"/>
+      <column type="field" hidden="0" width="-1" name="cross_section_max_width_model"/>
+      <column type="field" hidden="0" width="-1" name="cross_section_max_height_model"/>
+      <column type="field" hidden="0" width="-1" name="origin_model"/>
+      <column type="field" hidden="0" width="-1" name="crest_type_model"/>
+      <column type="field" hidden="0" width="-1" name="crest_level_model"/>
+      <column type="field" hidden="0" width="-1" name="sewerage_model"/>
+      <column type="field" hidden="0" width="-1" name="id_start_model"/>
+      <column type="field" hidden="0" width="-1" name="id_end_model"/>
+      <column type="field" hidden="0" width="-1" name="geom_type_model"/>
+      <column type="field" hidden="0" width="-1" name="geom_length_model"/>
+      <column type="field" hidden="0" width="-1" name="geom_area_model"/>
+      <column type="field" hidden="0" width="-1" name="dataset_model"/>
+      <column type="field" hidden="0" width="-1" name="naam_damo"/>
+      <column type="field" hidden="0" width="-1" name="opmerking_damo"/>
+      <column type="field" hidden="0" width="-1" name="indicatiewaterkerend_damo"/>
+      <column type="field" hidden="0" width="-1" name="indpeilregulpeilscheidend_damo"/>
+      <column type="field" hidden="0" width="-1" name="lengte_damo"/>
+      <column type="field" hidden="0" width="-1" name="hoogteopening_damo"/>
+      <column type="field" hidden="0" width="-1" name="breedteopening_damo"/>
+      <column type="field" hidden="0" width="-1" name="hoogtebinnenonderkantbene_damo"/>
+      <column type="field" hidden="0" width="-1" name="hoogtebinnenonderkantbov_damo"/>
+      <column type="field" hidden="0" width="-1" name="vormkoker_damo"/>
+      <column type="field" hidden="0" width="-1" name="soortmateriaal_damo"/>
+      <column type="field" hidden="0" width="-1" name="typekruising_damo"/>
+      <column type="field" hidden="0" width="-1" name="ws_categorie_damo"/>
+      <column type="field" hidden="0" width="-1" name="ws_bron_damo"/>
+      <column type="field" hidden="0" width="-1" name="ws_inwinningswijze_damo"/>
+      <column type="field" hidden="0" width="-1" name="ws_inwinningsdatum_damo"/>
+      <column type="field" hidden="0" width="-1" name="ws_inlaatfunctie_damo"/>
+      <column type="field" hidden="0" width="-1" name="ws_afsluitwijze1_damo"/>
+      <column type="field" hidden="0" width="-1" name="ws_afsluitwijze2_damo"/>
+      <column type="field" hidden="0" width="-1" name="shape_length_damo"/>
+      <column type="field" hidden="0" width="-1" name="geom_type_damo"/>
+      <column type="field" hidden="0" width="-1" name="geom_length_damo"/>
+      <column type="field" hidden="0" width="-1" name="geom_area_damo"/>
+      <column type="field" hidden="0" width="-1" name="dataset_damo"/>
+      <column type="field" hidden="0" width="-1" name="origin_damo"/>
+      <column type="field" hidden="0" width="-1" name="in_both"/>
+      <column type="field" hidden="0" width="-1" name="cmp_bob_bov"/>
+      <column type="field" hidden="0" width="-1" name="cmp_bob_bov_change_NaN"/>
+      <column type="field" hidden="0" width="-1" name="cmp_bob_bovpriority"/>
+      <column type="field" hidden="0" width="-1" name="cmp_bob_max"/>
+      <column type="field" hidden="0" width="-1" name="cmp_bob_max_change_NaN"/>
+      <column type="field" hidden="0" width="-1" name="cmp_bob_maxpriority"/>
+      <column type="actions" hidden="1" width="-1"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <storedexpressions/>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+    geom = feature.geometry()
+    control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>generatedlayout</editorlayout>
+  <editable>
+    <field name="breedteopening_damo" editable="1"/>
+    <field name="calculation_type_model" editable="1"/>
+    <field name="cmp_bob_bov" editable="1"/>
+    <field name="cmp_bob_bov_change_NaN" editable="1"/>
+    <field name="cmp_bob_bovpriority" editable="1"/>
+    <field name="cmp_bob_max" editable="1"/>
+    <field name="cmp_bob_max_change_NaN" editable="1"/>
+    <field name="cmp_bob_maxpriority" editable="1"/>
+    <field name="code" editable="1"/>
+    <field name="connection_node_end_id_model" editable="1"/>
+    <field name="connection_node_start_id_model" editable="1"/>
+    <field name="crest_level_model" editable="1"/>
+    <field name="crest_type_model" editable="1"/>
+    <field name="cross_section_definition_id_model" editable="1"/>
+    <field name="cross_section_max_height_model" editable="1"/>
+    <field name="cross_section_max_width_model" editable="1"/>
+    <field name="dataset_damo" editable="1"/>
+    <field name="dataset_model" editable="1"/>
+    <field name="discharge_coefficient_negative_model" editable="1"/>
+    <field name="discharge_coefficient_positive_model" editable="1"/>
+    <field name="display_name_model" editable="1"/>
+    <field name="dist_calc_points_model" editable="1"/>
+    <field name="fid" editable="1"/>
+    <field name="friction_type_model" editable="1"/>
+    <field name="friction_value_model" editable="1"/>
+    <field name="geom_area_damo" editable="1"/>
+    <field name="geom_area_model" editable="1"/>
+    <field name="geom_length_damo" editable="1"/>
+    <field name="geom_length_model" editable="1"/>
+    <field name="geom_type_damo" editable="1"/>
+    <field name="geom_type_model" editable="1"/>
+    <field name="hoogtebinnenonderkantbene_damo" editable="1"/>
+    <field name="hoogtebinnenonderkantbov_damo" editable="1"/>
+    <field name="hoogteopening_damo" editable="1"/>
+    <field name="id_end_model" editable="1"/>
+    <field name="id_model" editable="1"/>
+    <field name="id_start_model" editable="1"/>
+    <field name="in_both" editable="1"/>
+    <field name="indicatiewaterkerend_damo" editable="1"/>
+    <field name="indpeilregulpeilscheidend_damo" editable="1"/>
+    <field name="invert_level_end_point_model" editable="1"/>
+    <field name="invert_level_start_point_model" editable="1"/>
+    <field name="lengte_damo" editable="1"/>
+    <field name="level_0" editable="1"/>
+    <field name="level_1" editable="1"/>
+    <field name="naam_damo" editable="1"/>
+    <field name="opmerking_damo" editable="1"/>
+    <field name="origin_damo" editable="1"/>
+    <field name="origin_model" editable="1"/>
+    <field name="sewerage_model" editable="1"/>
+    <field name="shape_length_damo" editable="1"/>
+    <field name="soortmateriaal_damo" editable="1"/>
+    <field name="typekruising_damo" editable="1"/>
+    <field name="vormkoker_damo" editable="1"/>
+    <field name="wkt_geom_model" editable="1"/>
+    <field name="ws_afsluitwijze1_damo" editable="1"/>
+    <field name="ws_afsluitwijze2_damo" editable="1"/>
+    <field name="ws_bron_damo" editable="1"/>
+    <field name="ws_categorie_damo" editable="1"/>
+    <field name="ws_inlaatfunctie_damo" editable="1"/>
+    <field name="ws_inwinningsdatum_damo" editable="1"/>
+    <field name="ws_inwinningswijze_damo" editable="1"/>
+    <field name="zoom_category_model" editable="1"/>
+  </editable>
+  <labelOnTop>
+    <field name="breedteopening_damo" labelOnTop="0"/>
+    <field name="calculation_type_model" labelOnTop="0"/>
+    <field name="cmp_bob_bov" labelOnTop="0"/>
+    <field name="cmp_bob_bov_change_NaN" labelOnTop="0"/>
+    <field name="cmp_bob_bovpriority" labelOnTop="0"/>
+    <field name="cmp_bob_max" labelOnTop="0"/>
+    <field name="cmp_bob_max_change_NaN" labelOnTop="0"/>
+    <field name="cmp_bob_maxpriority" labelOnTop="0"/>
+    <field name="code" labelOnTop="0"/>
+    <field name="connection_node_end_id_model" labelOnTop="0"/>
+    <field name="connection_node_start_id_model" labelOnTop="0"/>
+    <field name="crest_level_model" labelOnTop="0"/>
+    <field name="crest_type_model" labelOnTop="0"/>
+    <field name="cross_section_definition_id_model" labelOnTop="0"/>
+    <field name="cross_section_max_height_model" labelOnTop="0"/>
+    <field name="cross_section_max_width_model" labelOnTop="0"/>
+    <field name="dataset_damo" labelOnTop="0"/>
+    <field name="dataset_model" labelOnTop="0"/>
+    <field name="discharge_coefficient_negative_model" labelOnTop="0"/>
+    <field name="discharge_coefficient_positive_model" labelOnTop="0"/>
+    <field name="display_name_model" labelOnTop="0"/>
+    <field name="dist_calc_points_model" labelOnTop="0"/>
+    <field name="fid" labelOnTop="0"/>
+    <field name="friction_type_model" labelOnTop="0"/>
+    <field name="friction_value_model" labelOnTop="0"/>
+    <field name="geom_area_damo" labelOnTop="0"/>
+    <field name="geom_area_model" labelOnTop="0"/>
+    <field name="geom_length_damo" labelOnTop="0"/>
+    <field name="geom_length_model" labelOnTop="0"/>
+    <field name="geom_type_damo" labelOnTop="0"/>
+    <field name="geom_type_model" labelOnTop="0"/>
+    <field name="hoogtebinnenonderkantbene_damo" labelOnTop="0"/>
+    <field name="hoogtebinnenonderkantbov_damo" labelOnTop="0"/>
+    <field name="hoogteopening_damo" labelOnTop="0"/>
+    <field name="id_end_model" labelOnTop="0"/>
+    <field name="id_model" labelOnTop="0"/>
+    <field name="id_start_model" labelOnTop="0"/>
+    <field name="in_both" labelOnTop="0"/>
+    <field name="indicatiewaterkerend_damo" labelOnTop="0"/>
+    <field name="indpeilregulpeilscheidend_damo" labelOnTop="0"/>
+    <field name="invert_level_end_point_model" labelOnTop="0"/>
+    <field name="invert_level_start_point_model" labelOnTop="0"/>
+    <field name="lengte_damo" labelOnTop="0"/>
+    <field name="level_0" labelOnTop="0"/>
+    <field name="level_1" labelOnTop="0"/>
+    <field name="naam_damo" labelOnTop="0"/>
+    <field name="opmerking_damo" labelOnTop="0"/>
+    <field name="origin_damo" labelOnTop="0"/>
+    <field name="origin_model" labelOnTop="0"/>
+    <field name="sewerage_model" labelOnTop="0"/>
+    <field name="shape_length_damo" labelOnTop="0"/>
+    <field name="soortmateriaal_damo" labelOnTop="0"/>
+    <field name="typekruising_damo" labelOnTop="0"/>
+    <field name="vormkoker_damo" labelOnTop="0"/>
+    <field name="wkt_geom_model" labelOnTop="0"/>
+    <field name="ws_afsluitwijze1_damo" labelOnTop="0"/>
+    <field name="ws_afsluitwijze2_damo" labelOnTop="0"/>
+    <field name="ws_bron_damo" labelOnTop="0"/>
+    <field name="ws_categorie_damo" labelOnTop="0"/>
+    <field name="ws_inlaatfunctie_damo" labelOnTop="0"/>
+    <field name="ws_inwinningsdatum_damo" labelOnTop="0"/>
+    <field name="ws_inwinningswijze_damo" labelOnTop="0"/>
+    <field name="zoom_category_model" labelOnTop="0"/>
+  </labelOnTop>
+  <reuseLastValue>
+    <field name="breedteopening_damo" reuseLastValue="0"/>
+    <field name="calculation_type_model" reuseLastValue="0"/>
+    <field name="cmp_bob_bov" reuseLastValue="0"/>
+    <field name="cmp_bob_bov_change_NaN" reuseLastValue="0"/>
+    <field name="cmp_bob_bovpriority" reuseLastValue="0"/>
+    <field name="cmp_bob_max" reuseLastValue="0"/>
+    <field name="cmp_bob_max_change_NaN" reuseLastValue="0"/>
+    <field name="cmp_bob_maxpriority" reuseLastValue="0"/>
+    <field name="code" reuseLastValue="0"/>
+    <field name="connection_node_end_id_model" reuseLastValue="0"/>
+    <field name="connection_node_start_id_model" reuseLastValue="0"/>
+    <field name="crest_level_model" reuseLastValue="0"/>
+    <field name="crest_type_model" reuseLastValue="0"/>
+    <field name="cross_section_definition_id_model" reuseLastValue="0"/>
+    <field name="cross_section_max_height_model" reuseLastValue="0"/>
+    <field name="cross_section_max_width_model" reuseLastValue="0"/>
+    <field name="dataset_damo" reuseLastValue="0"/>
+    <field name="dataset_model" reuseLastValue="0"/>
+    <field name="discharge_coefficient_negative_model" reuseLastValue="0"/>
+    <field name="discharge_coefficient_positive_model" reuseLastValue="0"/>
+    <field name="display_name_model" reuseLastValue="0"/>
+    <field name="dist_calc_points_model" reuseLastValue="0"/>
+    <field name="fid" reuseLastValue="0"/>
+    <field name="friction_type_model" reuseLastValue="0"/>
+    <field name="friction_value_model" reuseLastValue="0"/>
+    <field name="geom_area_damo" reuseLastValue="0"/>
+    <field name="geom_area_model" reuseLastValue="0"/>
+    <field name="geom_length_damo" reuseLastValue="0"/>
+    <field name="geom_length_model" reuseLastValue="0"/>
+    <field name="geom_type_damo" reuseLastValue="0"/>
+    <field name="geom_type_model" reuseLastValue="0"/>
+    <field name="hoogtebinnenonderkantbene_damo" reuseLastValue="0"/>
+    <field name="hoogtebinnenonderkantbov_damo" reuseLastValue="0"/>
+    <field name="hoogteopening_damo" reuseLastValue="0"/>
+    <field name="id_end_model" reuseLastValue="0"/>
+    <field name="id_model" reuseLastValue="0"/>
+    <field name="id_start_model" reuseLastValue="0"/>
+    <field name="in_both" reuseLastValue="0"/>
+    <field name="indicatiewaterkerend_damo" reuseLastValue="0"/>
+    <field name="indpeilregulpeilscheidend_damo" reuseLastValue="0"/>
+    <field name="invert_level_end_point_model" reuseLastValue="0"/>
+    <field name="invert_level_start_point_model" reuseLastValue="0"/>
+    <field name="lengte_damo" reuseLastValue="0"/>
+    <field name="level_0" reuseLastValue="0"/>
+    <field name="level_1" reuseLastValue="0"/>
+    <field name="naam_damo" reuseLastValue="0"/>
+    <field name="opmerking_damo" reuseLastValue="0"/>
+    <field name="origin_damo" reuseLastValue="0"/>
+    <field name="origin_model" reuseLastValue="0"/>
+    <field name="sewerage_model" reuseLastValue="0"/>
+    <field name="shape_length_damo" reuseLastValue="0"/>
+    <field name="soortmateriaal_damo" reuseLastValue="0"/>
+    <field name="typekruising_damo" reuseLastValue="0"/>
+    <field name="vormkoker_damo" reuseLastValue="0"/>
+    <field name="wkt_geom_model" reuseLastValue="0"/>
+    <field name="ws_afsluitwijze1_damo" reuseLastValue="0"/>
+    <field name="ws_afsluitwijze2_damo" reuseLastValue="0"/>
+    <field name="ws_bron_damo" reuseLastValue="0"/>
+    <field name="ws_categorie_damo" reuseLastValue="0"/>
+    <field name="ws_inlaatfunctie_damo" reuseLastValue="0"/>
+    <field name="ws_inwinningsdatum_damo" reuseLastValue="0"/>
+    <field name="ws_inwinningswijze_damo" reuseLastValue="0"/>
+    <field name="zoom_category_model" reuseLastValue="0"/>
+  </reuseLastValue>
+  <dataDefinedFieldProperties/>
+  <widgets/>
+  <previewExpression>"display_name_model"</previewExpression>
+  <mapTip></mapTip>
+  <layerGeometryType>1</layerGeometryType>
+</qgis>

--- a/hhnk_threedi_tools/core/vergelijkingstool/styling/duikersifonhevel.qml
+++ b/hhnk_threedi_tools/core/vergelijkingstool/styling/duikersifonhevel.qml
@@ -1,0 +1,398 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis labelsEnabled="0" version="3.26.1-Buenos Aires" styleCategories="LayerConfiguration|Symbology|Symbology3D|Labeling" readOnly="0">
+ <flags>
+  <Identifiable>1</Identifiable>
+  <Removable>1</Removable>
+  <Searchable>1</Searchable>
+  <Private>0</Private>
+ </flags>
+ <renderer-v2 attr="in_both" type="categorizedSymbol" referencescale="-1" forceraster="0" enableorderby="0" symbollevels="0">
+  <categories>
+   <category type="string" render="true" value="castricum both" symbol="2" label="castricum both" symbol="0"/>
+   <category type="string" render="true" value="castricum both" symbol="2" label="castricum both" symbol="1"/>
+   <category type="string" render="true" value="castricum damo" symbol="0" label="castricum damo" symbol="2"/>
+  </categories>
+  <symbols>
+   <symbol is_animated="0" alpha="1" type="line" clip_to_extent="1" frame_rate="10" name="0" force_rhr="0">
+    <data_defined_properties>
+     <Option type="Map">
+      <Option type="QString" value="" name="name"/>
+      <Option name="properties"/>
+      <Option type="QString" value="collection" name="type"/>
+     </Option>
+    </data_defined_properties>
+    <layer class="SimpleLine" pass="0" locked="0" enabled="1">
+     <Option type="Map">
+      <Option type="QString" value="0" name="align_dash_pattern"/>
+      <Option type="QString" value="square" name="capstyle"/>
+      <Option type="QString" value="5;2" name="customdash"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+      <Option type="QString" value="MM" name="customdash_unit"/>
+      <Option type="QString" value="0" name="dash_pattern_offset"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+      <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+      <Option type="QString" value="0" name="draw_inside_polygon"/>
+      <Option type="QString" value="bevel" name="joinstyle"/>
+      <Option type="QString" value="255,127,0,255" name="line_color"/>
+      <Option type="QString" value="solid" name="line_style"/>
+      <Option type="QString" value="1" name="line_width"/>
+      <Option type="QString" value="MM" name="line_width_unit"/>
+      <Option type="QString" value="0" name="offset"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+      <Option type="QString" value="MM" name="offset_unit"/>
+      <Option type="QString" value="0" name="ring_filter"/>
+      <Option type="QString" value="0" name="trim_distance_end"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+      <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+      <Option type="QString" value="0" name="trim_distance_start"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+      <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+      <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+      <Option type="QString" value="0" name="use_custom_dash"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+     </Option>
+     <prop v="0" k="align_dash_pattern"/>
+     <prop v="square" k="capstyle"/>
+     <prop v="5;2" k="customdash"/>
+     <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+     <prop v="MM" k="customdash_unit"/>
+     <prop v="0" k="dash_pattern_offset"/>
+     <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
+     <prop v="MM" k="dash_pattern_offset_unit"/>
+     <prop v="0" k="draw_inside_polygon"/>
+     <prop v="bevel" k="joinstyle"/>
+     <prop v="255,127,0,255" k="line_color"/>
+     <prop v="solid" k="line_style"/>
+     <prop v="1" k="line_width"/>
+     <prop v="MM" k="line_width_unit"/>
+     <prop v="0" k="offset"/>
+     <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+     <prop v="MM" k="offset_unit"/>
+     <prop v="0" k="ring_filter"/>
+     <prop v="0" k="trim_distance_end"/>
+     <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
+     <prop v="MM" k="trim_distance_end_unit"/>
+     <prop v="0" k="trim_distance_start"/>
+     <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
+     <prop v="MM" k="trim_distance_start_unit"/>
+     <prop v="0" k="tweak_dash_pattern_on_corners"/>
+     <prop v="0" k="use_custom_dash"/>
+     <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+     <data_defined_properties>
+      <Option type="Map">
+       <Option type="QString" value="" name="name"/>
+       <Option name="properties"/>
+       <Option type="QString" value="collection" name="type"/>
+      </Option>
+     </data_defined_properties>
+    </layer>
+   </symbol>
+   <symbol is_animated="0" alpha="1" type="line" clip_to_extent="1" frame_rate="10" name="1" force_rhr="0">
+    <data_defined_properties>
+     <Option type="Map">
+      <Option type="QString" value="" name="name"/>
+      <Option name="properties"/>
+      <Option type="QString" value="collection" name="type"/>
+     </Option>
+    </data_defined_properties>
+    <layer class="SimpleLine" pass="0" locked="0" enabled="1">
+     <Option type="Map">
+      <Option type="QString" value="0" name="align_dash_pattern"/>
+      <Option type="QString" value="square" name="capstyle"/>
+      <Option type="QString" value="5;2" name="customdash"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+      <Option type="QString" value="MM" name="customdash_unit"/>
+      <Option type="QString" value="0" name="dash_pattern_offset"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+      <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+      <Option type="QString" value="0" name="draw_inside_polygon"/>
+      <Option type="QString" value="bevel" name="joinstyle"/>
+      <Option type="QString" value="62,131,249,255" name="line_color"/>
+      <Option type="QString" value="solid" name="line_style"/>
+      <Option type="QString" value="1" name="line_width"/>
+      <Option type="QString" value="MM" name="line_width_unit"/>
+      <Option type="QString" value="0" name="offset"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+      <Option type="QString" value="MM" name="offset_unit"/>
+      <Option type="QString" value="0" name="ring_filter"/>
+      <Option type="QString" value="0" name="trim_distance_end"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+      <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+      <Option type="QString" value="0" name="trim_distance_start"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+      <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+      <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+      <Option type="QString" value="0" name="use_custom_dash"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+     </Option>
+     <prop v="0" k="align_dash_pattern"/>
+     <prop v="square" k="capstyle"/>
+     <prop v="5;2" k="customdash"/>
+     <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+     <prop v="MM" k="customdash_unit"/>
+     <prop v="0" k="dash_pattern_offset"/>
+     <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
+     <prop v="MM" k="dash_pattern_offset_unit"/>
+     <prop v="0" k="draw_inside_polygon"/>
+     <prop v="bevel" k="joinstyle"/>
+     <prop v="62,131,249,255" k="line_color"/>
+     <prop v="solid" k="line_style"/>
+     <prop v="1" k="line_width"/>
+     <prop v="MM" k="line_width_unit"/>
+     <prop v="0" k="offset"/>
+     <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+     <prop v="MM" k="offset_unit"/>
+     <prop v="0" k="ring_filter"/>
+     <prop v="0" k="trim_distance_end"/>
+     <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
+     <prop v="MM" k="trim_distance_end_unit"/>
+     <prop v="0" k="trim_distance_start"/>
+     <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
+     <prop v="MM" k="trim_distance_start_unit"/>
+     <prop v="0" k="tweak_dash_pattern_on_corners"/>
+     <prop v="0" k="use_custom_dash"/>
+     <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+     <data_defined_properties>
+      <Option type="Map">
+       <Option type="QString" value="" name="name"/>
+       <Option name="properties"/>
+       <Option type="QString" value="collection" name="type"/>
+      </Option>
+     </data_defined_properties>
+    </layer>
+   </symbol>
+   <symbol is_animated="0" alpha="1" type="line" clip_to_extent="1" frame_rate="10" name="2" force_rhr="0">
+    <data_defined_properties>
+     <Option type="Map">
+      <Option type="QString" value="" name="name"/>
+      <Option name="properties"/>
+      <Option type="QString" value="collection" name="type"/>
+     </Option>
+    </data_defined_properties>
+    <layer class="SimpleLine" pass="0" locked="0" enabled="1">
+     <Option type="Map">
+      <Option type="QString" value="0" name="align_dash_pattern"/>
+      <Option type="QString" value="square" name="capstyle"/>
+      <Option type="QString" value="5;2" name="customdash"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+      <Option type="QString" value="MM" name="customdash_unit"/>
+      <Option type="QString" value="0" name="dash_pattern_offset"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+      <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+      <Option type="QString" value="0" name="draw_inside_polygon"/>
+      <Option type="QString" value="bevel" name="joinstyle"/>
+      <Option type="QString" value="255,1,0,255" name="line_color"/>
+      <Option type="QString" value="solid" name="line_style"/>
+      <Option type="QString" value="0" name="line_width"/>
+      <Option type="QString" value="MM" name="line_width_unit"/>
+      <Option type="QString" value="0" name="offset"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+      <Option type="QString" value="MM" name="offset_unit"/>
+      <Option type="QString" value="0" name="ring_filter"/>
+      <Option type="QString" value="0" name="trim_distance_end"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+      <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+      <Option type="QString" value="0" name="trim_distance_start"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+      <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+      <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+      <Option type="QString" value="0" name="use_custom_dash"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+     </Option>
+     <prop v="0" k="align_dash_pattern"/>
+     <prop v="square" k="capstyle"/>
+     <prop v="5;2" k="customdash"/>
+     <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+     <prop v="MM" k="customdash_unit"/>
+     <prop v="0" k="dash_pattern_offset"/>
+     <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
+     <prop v="MM" k="dash_pattern_offset_unit"/>
+     <prop v="0" k="draw_inside_polygon"/>
+     <prop v="bevel" k="joinstyle"/>
+     <prop v="255,1,0,255" k="line_color"/>
+     <prop v="solid" k="line_style"/>
+     <prop v="0" k="line_width"/>
+     <prop v="MM" k="line_width_unit"/>
+     <prop v="0" k="offset"/>
+     <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+     <prop v="MM" k="offset_unit"/>
+     <prop v="0" k="ring_filter"/>
+     <prop v="0" k="trim_distance_end"/>
+     <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
+     <prop v="MM" k="trim_distance_end_unit"/>
+     <prop v="0" k="trim_distance_start"/>
+     <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
+     <prop v="MM" k="trim_distance_start_unit"/>
+     <prop v="0" k="tweak_dash_pattern_on_corners"/>
+     <prop v="0" k="use_custom_dash"/>
+     <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+     <data_defined_properties>
+      <Option type="Map">
+       <Option type="QString" value="" name="name"/>
+       <Option type="Map" name="properties">
+        <Option type="Map" name="outlineStyle">
+         <Option type="bool" value="true" name="active"/>
+         <Option type="QString" value="if(&quot;number_of_critical&quot;=0,'no','solid')" name="expression"/>
+         <Option type="int" value="3" name="type"/>
+        </Option>
+        <Option type="Map" name="outlineWidth">
+         <Option type="bool" value="true" name="active"/>
+         <Option type="QString" value="&quot;number_of_critical&quot;" name="expression"/>
+         <Option type="int" value="3" name="type"/>
+        </Option>
+       </Option>
+       <Option type="QString" value="collection" name="type"/>
+      </Option>
+     </data_defined_properties>
+    </layer>
+    <layer class="SimpleLine" pass="0" locked="0" enabled="1">
+     <Option type="Map">
+      <Option type="QString" value="0" name="align_dash_pattern"/>
+      <Option type="QString" value="square" name="capstyle"/>
+      <Option type="QString" value="5;2" name="customdash"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+      <Option type="QString" value="MM" name="customdash_unit"/>
+      <Option type="QString" value="0" name="dash_pattern_offset"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+      <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+      <Option type="QString" value="0" name="draw_inside_polygon"/>
+      <Option type="QString" value="bevel" name="joinstyle"/>
+      <Option type="QString" value="197,197,197,0" name="line_color"/>
+      <Option type="QString" value="solid" name="line_style"/>
+      <Option type="QString" value="1" name="line_width"/>
+      <Option type="QString" value="MM" name="line_width_unit"/>
+      <Option type="QString" value="0" name="offset"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+      <Option type="QString" value="MM" name="offset_unit"/>
+      <Option type="QString" value="0" name="ring_filter"/>
+      <Option type="QString" value="0" name="trim_distance_end"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+      <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+      <Option type="QString" value="0" name="trim_distance_start"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+      <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+      <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+      <Option type="QString" value="0" name="use_custom_dash"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+     </Option>
+     <prop v="0" k="align_dash_pattern"/>
+     <prop v="square" k="capstyle"/>
+     <prop v="5;2" k="customdash"/>
+     <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+     <prop v="MM" k="customdash_unit"/>
+     <prop v="0" k="dash_pattern_offset"/>
+     <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
+     <prop v="MM" k="dash_pattern_offset_unit"/>
+     <prop v="0" k="draw_inside_polygon"/>
+     <prop v="bevel" k="joinstyle"/>
+     <prop v="197,197,197,128" k="line_color"/>
+     <prop v="solid" k="line_style"/>
+     <prop v="1" k="line_width"/>
+     <prop v="MM" k="line_width_unit"/>
+     <prop v="0" k="offset"/>
+     <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+     <prop v="MM" k="offset_unit"/>
+     <prop v="0" k="ring_filter"/>
+     <prop v="0" k="trim_distance_end"/>
+     <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
+     <prop v="MM" k="trim_distance_end_unit"/>
+     <prop v="0" k="trim_distance_start"/>
+     <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
+     <prop v="MM" k="trim_distance_start_unit"/>
+     <prop v="0" k="tweak_dash_pattern_on_corners"/>
+     <prop v="0" k="use_custom_dash"/>
+     <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+     <data_defined_properties>
+      <Option type="Map">
+       <Option type="QString" value="" name="name"/>
+       <Option name="properties"/>
+       <Option type="QString" value="collection" name="type"/>
+      </Option>
+     </data_defined_properties>
+    </layer>
+   </symbol>
+  </symbols>
+  <source-symbol>
+   <symbol is_animated="0" alpha="1" type="line" clip_to_extent="1" frame_rate="10" name="0" force_rhr="0">
+    <data_defined_properties>
+     <Option type="Map">
+      <Option type="QString" value="" name="name"/>
+      <Option name="properties"/>
+      <Option type="QString" value="collection" name="type"/>
+     </Option>
+    </data_defined_properties>
+    <layer class="SimpleLine" pass="0" locked="0" enabled="1">
+     <Option type="Map">
+      <Option type="QString" value="0" name="align_dash_pattern"/>
+      <Option type="QString" value="square" name="capstyle"/>
+      <Option type="QString" value="5;2" name="customdash"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+      <Option type="QString" value="MM" name="customdash_unit"/>
+      <Option type="QString" value="0" name="dash_pattern_offset"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+      <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+      <Option type="QString" value="0" name="draw_inside_polygon"/>
+      <Option type="QString" value="bevel" name="joinstyle"/>
+      <Option type="QString" value="213,180,60,255" name="line_color"/>
+      <Option type="QString" value="solid" name="line_style"/>
+      <Option type="QString" value="1" name="line_width"/>
+      <Option type="QString" value="MM" name="line_width_unit"/>
+      <Option type="QString" value="0" name="offset"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+      <Option type="QString" value="MM" name="offset_unit"/>
+      <Option type="QString" value="0" name="ring_filter"/>
+      <Option type="QString" value="0" name="trim_distance_end"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+      <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+      <Option type="QString" value="0" name="trim_distance_start"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+      <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+      <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+      <Option type="QString" value="0" name="use_custom_dash"/>
+      <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+     </Option>
+     <prop v="0" k="align_dash_pattern"/>
+     <prop v="square" k="capstyle"/>
+     <prop v="5;2" k="customdash"/>
+     <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+     <prop v="MM" k="customdash_unit"/>
+     <prop v="0" k="dash_pattern_offset"/>
+     <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
+     <prop v="MM" k="dash_pattern_offset_unit"/>
+     <prop v="0" k="draw_inside_polygon"/>
+     <prop v="bevel" k="joinstyle"/>
+     <prop v="213,180,60,255" k="line_color"/>
+     <prop v="solid" k="line_style"/>
+     <prop v="1" k="line_width"/>
+     <prop v="MM" k="line_width_unit"/>
+     <prop v="0" k="offset"/>
+     <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+     <prop v="MM" k="offset_unit"/>
+     <prop v="0" k="ring_filter"/>
+     <prop v="0" k="trim_distance_end"/>
+     <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
+     <prop v="MM" k="trim_distance_end_unit"/>
+     <prop v="0" k="trim_distance_start"/>
+     <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
+     <prop v="MM" k="trim_distance_start_unit"/>
+     <prop v="0" k="tweak_dash_pattern_on_corners"/>
+     <prop v="0" k="use_custom_dash"/>
+     <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+     <data_defined_properties>
+      <Option type="Map">
+       <Option type="QString" value="" name="name"/>
+       <Option name="properties"/>
+       <Option type="QString" value="collection" name="type"/>
+      </Option>
+     </data_defined_properties>
+    </layer>
+   </symbol>
+  </source-symbol>
+  <rotation/>
+  <sizescale/>
+ </renderer-v2>
+ <blendMode>0</blendMode>
+ <featureBlendMode>0</featureBlendMode>
+ <previewExpression>"code"</previewExpression>
+ <layerGeometryType>1</layerGeometryType>
+</qgis>


### PR DESCRIPTION
Within HHNK we develops polder models for flood protection studies. These models are initially built automatically from management data and later refined by hydrologists. Over time, changes in the water system—such as infrastructure updates or area development—can make models outdated. To address this, HHNK created a comparison tool that identifies discrepancies between models and current data. The tool performs two main comparisons: between old and new source data (DAMO and HDB), and between models and source data. It analyzes differences based on object codes and attributes, using configuration files for complex comparisons. Input includes databases, model files, translation rules, and styling files. The output consists of GeoPackages showing statistical differences in object count, length, or area across datasets, categorized by layer and structure type. This helps determine when models need updating, ensuring studies are based on accurate, current representations of the water system.

This first PR  reefers to the working version develop by RHK. It includes 3 main Classes: DAMO, Threedimodel, Dataset. It also include 2 different ways to set symbiology either with a qml file or a hardcoded qml file. Within the config file it is possible to see all layers to be compare from DAMO, HDB, and 3di. It is important to notice that the comparison between model and data source is done in the basis of the version 3.12 from 3di which used to work with sqile, the new version works with geopackge. 