### PR TITLE
Add auto_fixable parameter to validation rules JSON

### DIFF
--- a/hhnk_threedi_tools/resources/schematisation_builder/validationrules.json
+++ b/hhnk_threedi_tools/resources/schematisation_builder/validationrules.json
@@ -165,7 +165,8 @@
 						"snaps_to_hydroobject": {
 							"method": "overall"
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 100,
@@ -182,7 +183,8 @@
 							"left": "nr_of_profielpunten",
 							"right": 3
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 101,
@@ -201,7 +203,8 @@
 							"max": 2,
 							"inclusive": false
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 102,
@@ -220,7 +223,8 @@
 							"max": 20,
 							"inclusive": false
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 103,
@@ -237,7 +241,8 @@
 							"left": "jaarinwinning",
 							"right": 2009
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 104,
@@ -256,7 +261,8 @@
 							"max": 3,
 							"inclusive": false
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 105,
@@ -273,7 +279,8 @@
 							"left": "maximalehoogteprofiel",
 							"right": 6
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 106,
@@ -290,7 +297,8 @@
 							"left": "max_cross_product",
 							"right": 0.5
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 107,
@@ -307,7 +315,8 @@
 							"left": "bodemhoogte",
 							"right": "maaiveldhoogte"
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 108,
@@ -324,7 +333,8 @@
 							"left": "isascending",
 							"right": 1
 						}
-					}
+					},
+					"auto_fixable": false
 				}
 			]
 		},
@@ -393,7 +403,8 @@
 							"max": 325,
 							"inclusive": false
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 1,
@@ -411,7 +422,8 @@
 							"max": 325,
 							"inclusive": false
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 2,
@@ -427,7 +439,8 @@
 							"left": "hoogtebinnenonderkantbov",
 							"right": "maaiveldhoogte"
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 3,
@@ -443,7 +456,8 @@
 							"left": "hoogtebinnenonderkantbene",
 							"right": "maaiveldhoogte"
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 4,
@@ -459,7 +473,8 @@
 							"left": "lengte",
 							"right": 1.0
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 5,
@@ -483,7 +498,8 @@
 							"left": "breedteopening",
 							"right": "hoogteopening"
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 6,
@@ -499,7 +515,8 @@
 							"tolerance": 0.01,
 							"method": "ends"
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 7,
@@ -517,7 +534,8 @@
 							"max": 0.05,
 							"inclusive": false
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 8,
@@ -533,7 +551,8 @@
 							"left": "verval",
 							"right": 0.5
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 9,
@@ -548,7 +567,8 @@
 						"not_overlapping": {
 							"tolerance": 0.01
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 10,
@@ -567,7 +587,8 @@
 							"logical_operator": "GT",
 							"direction": "upstream"
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 11,
@@ -586,7 +607,8 @@
 							"logical_operator": "GT",
 							"direction": "downstream"
 						}
-					}
+					},
+					"auto_fixable": false
 				}
 			]
 		},
@@ -641,7 +663,8 @@
 							"max": 325,
 							"inclusive": false
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 1,
@@ -659,7 +682,8 @@
 							"max": 325,
 							"inclusive": false
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 2,
@@ -677,7 +701,8 @@
 							"max": 10,
 							"inclusive": false
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 3,
@@ -695,7 +720,8 @@
 							"max": 50,
 							"inclusive": false
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 4,
@@ -711,7 +737,8 @@
 							"left": "hoogteopening",
 							"right": 0
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 5,
@@ -735,7 +762,8 @@
 							"left": "maximalehoogteopening",
 							"right": "kunstwerkopening_hoogte_m"
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 6,
@@ -759,7 +787,8 @@
 							"left": "minimalehoogtebovenkant",
 							"right": "kunstwerkopening_laagstedoorstroomhoogte"
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 7,
@@ -783,7 +812,8 @@
 							"left": "maximalehoogtebovenkant",
 							"right": "kunstwerkopening_hoogstedoorstroomhoogte"
 						}
-					}
+					},
+					"auto_fixable": false
 				}
 			]
 		},
@@ -852,7 +882,8 @@
 							"max": 325,
 							"inclusive": false
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 1,
@@ -870,7 +901,8 @@
 							"max": 325,
 							"inclusive": false
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 2,
@@ -895,7 +927,8 @@
 							"left": "laagstedoorstroombreedte",
 							"right": "hoogstedoorstroombreedte"
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 3,
@@ -911,7 +944,8 @@
 							"left": "laagstedoorstroomhoogte",
 							"right": "hoogstedoorstroomhoogte"
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 4,
@@ -937,7 +971,8 @@
 							"left": "laagstedoorstroomhoogte",
 							"right": "hoogstedoorstroomhoogte"
 						}
-					}
+					},
+					"auto_fixable": false
 				}
 			]
 		},
@@ -1042,7 +1077,8 @@
 							"max": 325,
 							"inclusive": false
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 1,
@@ -1059,7 +1095,8 @@
 							"left": "hoogteconstructie",
 							"right": "maaiveldhoogte"
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 2,
@@ -1075,7 +1112,8 @@
 							"left": "kruinbreedte",
 							"right": 0.3
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 3,
@@ -1091,7 +1129,8 @@
 							"method": "overall",
 							"tolerance": 1
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 4,
@@ -1107,7 +1146,8 @@
 							"left": "kruinbreedte",
 							"right": "kunstwerkopening_hoogstedoorstroombreedte"
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 5,
@@ -1123,7 +1163,8 @@
 							"left": "kunstwerkopening_hoogstedoorstroomhoogte",
 							"right": "hoogteconstructie"
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 6,
@@ -1138,7 +1179,8 @@
 						"distant_to_others": {
 							"distance": 1
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 7,
@@ -1163,7 +1205,8 @@
 							"left": "kunstwerkopening_regelmiddel_aantal_regelmiddelen",
 							"right": 0
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 8,
@@ -1178,7 +1221,8 @@
 						"not_overlapping": {
 							"tolerance": 1
 						}
-					}
+					},
+					"auto_fixable": false
 				}
 			]
 		},
@@ -1236,7 +1280,8 @@
 							"max": 325,
 							"inclusive": false
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 1,
@@ -1254,7 +1299,8 @@
 							"max": 325,
 							"inclusive": false
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 2,
@@ -1272,7 +1318,8 @@
 							"max": 30,
 							"inclusive": false
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 3,
@@ -1290,7 +1337,8 @@
 							"max": 50,
 							"inclusive": false
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 4,
@@ -1308,7 +1356,8 @@
 							"max": 50,
 							"inclusive": false
 						}
-					}
+					},
+					"auto_fixable": false
 				}
 			]
 		},
@@ -1330,7 +1379,8 @@
 							"left": "maximalecapaciteit",
 							"right": 0
 						}
-					}
+					},
+					"auto_fixable": false
 				}
 			]
 		},
@@ -1381,7 +1431,8 @@
 							"left": "pomp_aantal_pompen",
 							"right": 0
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 1,
@@ -1398,7 +1449,8 @@
 							"left": "pomp_capaciteit",
 							"right": 0
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 2,
@@ -1414,7 +1466,8 @@
 						"not_overlapping": {
 							"tolerance": 1
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 101,
@@ -1433,7 +1486,8 @@
 							"max": 700,
 							"inclusive": true
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 102,
@@ -1450,7 +1504,8 @@
 							"method": "overall",
 							"tolerance": 1
 						}
-					}
+					},
+					"auto_fixable": false
 				}
 			]
 		},
@@ -1471,7 +1526,8 @@
 							"length": 1,
 							"statistic": "min"
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 1,
@@ -1486,7 +1542,8 @@
 						"splitted_at_junction": {
 							"tolerance": 0.01
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 2,
@@ -1504,7 +1561,8 @@
 								"duikersifonhevel"
 							]
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 3,
@@ -1519,7 +1577,8 @@
 						"no_dangling_node": {
 							"tolerance": 0.01
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 4,
@@ -1541,7 +1600,8 @@
 							"tolerance": 0.01,
 							"distance": 25
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 5,
@@ -1561,7 +1621,8 @@
 							],
 							"tolerance": 1
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 6,
@@ -1583,7 +1644,8 @@
 							"tolerance": 0.01,
 							"distance": 25
 						}
-					}
+					},
+					"auto_fixable": false
 				}
 			]
 		},
@@ -1659,7 +1721,8 @@
 						"consistent_period": {
 							"max_gap": 1
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 1,
@@ -1679,7 +1742,8 @@
 						"join_object_exists": {
 							"join_object": "pomp"
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 2,
@@ -1699,7 +1763,8 @@
 						"join_object_exists": {
 							"join_object": "regelmiddel"
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 3,
@@ -1719,7 +1784,8 @@
 						"join_object_exists": {
 							"join_object": "hydrologischerandvoorwaarde"
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 4,
@@ -1743,7 +1809,8 @@
 							"left": "vastewaarde",
 							"right": "pomp_pompcapaciteit_m3s"
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 5,
@@ -1767,7 +1834,8 @@
 							"left": "vastewaarde",
 							"right": "hoogteopening"
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 6,
@@ -1793,7 +1861,8 @@
 							"max": "maximalehoogtebovenkant",
 							"inclusive": true
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 7,
@@ -1816,7 +1885,8 @@
 								"pompdebiet"
 							]
 						}
-					}
+					},
+					"auto_fixable": false
 				},
 				{
 					"id": 8,
@@ -1840,7 +1910,8 @@
 								"hoogte opening"
 							]
 						}
-					}
+					},
+					"auto_fixable": false
 				}
 			]
 		}


### PR DESCRIPTION
Changes for validation viewer, this ticket: https://github.com/threedi/hhnk-threedi-tools/issues/293

It works together with changes in the code of the HyDAMOValidatieModule (PR in HyDAMOValidatieModule repo: https://github.com/HHNK/HyDAMOValidatieModule/pull/6).

We've added two columns invalid_auto_fixable and invalid_manual_fixable which will be used in QGIS validation viewer to order and symbolize the validation results on the map.

<img width="1920" height="1140" alt="image" src="https://github.com/user-attachments/assets/3b0a3e29-3713-4130-9062-1628f9028e0a" />
