### PR TITLE
28148 Culvert structure control check

### DIFF
--- a/hhnk_threedi_tools/core/checks/schematisation/schematisation_checks_main.py
+++ b/hhnk_threedi_tools/core/checks/schematisation/schematisation_checks_main.py
@@ -44,8 +44,8 @@ class HhnkSchematisationChecks:
 
         self.results = results
 
-    def run_controlled_structures(self, overwrite: bool = False):
-        """Create leayer with structure control in schematisation"""
+    def run_controlled_structures(self, overwrite: bool = False):  # TODO WVE
+        """Create layer with structure control in schematisation"""
         self.structure_control = StructureControl(
             model=self.database,
             hdb_control_layer=self.folder.source_data.hdb.layers.sturing_kunstwerken,

--- a/hhnk_threedi_tools/core/checks/schematisation/structure_control.py
+++ b/hhnk_threedi_tools/core/checks/schematisation/structure_control.py
@@ -216,11 +216,11 @@ class StructureControl:
         self,
     ) -> gpd.GeoDataFrame:
         """
-        Export orifice rows to self.output_file.Uses the same geometry as self.control_gdf.
+        Export culvert rows to self.output_file.Uses the same geometry as self.control_gdf.
         If there are none, writes an empty layer and logs info.
         """
         if self.output_file is None:
-            logger.debug("No output_file configured; skipping orifice export.")
+            logger.debug("No output_file configured; skipping culvert export.")
             return gpd.GeoDataFrame()
 
         out = self.output_file

--- a/hhnk_threedi_tools/core/checks/schematisation/structure_control.py
+++ b/hhnk_threedi_tools/core/checks/schematisation/structure_control.py
@@ -212,7 +212,7 @@ class StructureControl:
         self.control_gdf = gpd.GeoDataFrame(self.control_gdf)
         self.control_gdf.to_file(self.output_file)
 
-    def export_gestuurde_orifice(
+    def export_gestuurde_culvert(
         self,
     ) -> gpd.GeoDataFrame:
         """
@@ -224,8 +224,8 @@ class StructureControl:
             return gpd.GeoDataFrame()
 
         out = self.output_file
-        layer_name = "gestuurde_orifice"
-        gdf_orifice = self.control_gdf.loc[self.control_gdf["target_type"] == "v2_orifice"].copy()
+        layer_name = "gestuurde_culvert"
+        gdf_orifice = self.control_gdf.loc[self.control_gdf["target_type"] == "culvert"].copy()
 
         if out.exists() and layer_name in fiona.listlayers(out):
             fiona.remove(str(out), layer=layer_name, driver="GPKG")
@@ -255,7 +255,7 @@ class StructureControl:
 
             self.save()
 
-            self.export_gestuurde_orifice()
+            self.export_gestuurde_culvert()
             return self.control_gdf
 
 
@@ -331,7 +331,6 @@ def update_sorted_actiontable(database: hrt.SpatialDatabase, queries: list[str])
 if __name__ == "__main__":
     for i in range(1, 5):
         TEST_MODEL = Path(__file__).parents[i].absolute() / "tests/data/model_test/"
-        TEST_MODEL = r"Y:\02.modellen\grootslag_leggertool"
         folder = Folders(TEST_MODEL)
         if folder.exists():
             break

--- a/hhnk_threedi_tools/core/checks/schematisation/structure_control.py
+++ b/hhnk_threedi_tools/core/checks/schematisation/structure_control.py
@@ -212,11 +212,11 @@ class StructureControl:
         self.control_gdf = gpd.GeoDataFrame(self.control_gdf)
         self.control_gdf.to_file(self.output_file)
 
-    def export_gestuurde_culvert(
+    def export_gestuurde_duiker(
         self,
     ) -> gpd.GeoDataFrame:
         """
-        Export culvert rows to self.output_file.Uses the same geometry as self.control_gdf.
+        Export culvert to self.output_file.Uses the same geometry as self.control_gdf.
         If there are none, writes an empty layer and logs info.
         """
         if self.output_file is None:
@@ -224,15 +224,19 @@ class StructureControl:
             return gpd.GeoDataFrame()
 
         out = self.output_file
-        layer_name = "gestuurde_culvert"
-        gdf_orifice = self.control_gdf.loc[self.control_gdf["target_type"] == "culvert"].copy()
+        layer_name = "gestuurde_duiker"
+        gdf_gestuurde_culvert = self.control_gdf.loc[self.control_gdf["target_type"] == "culvert"].copy()
 
-        if out.exists() and layer_name in fiona.listlayers(out):
-            fiona.remove(str(out), layer=layer_name, driver="GPKG")
+        sturing_kunstwerken = hrt.SpatialDatabase(out)
+        available_layers = sturing_kunstwerken.available_layers()
 
-        gdf_orifice.to_file(out, driver="GPKG", layer=layer_name)
+        if layer_name in available_layers:
+            logger.info(f"Overwriting existing layer '{layer_name}' in {out}.")
+        else:
+            logger.info(f"Creating new layer '{layer_name}' in {out}.")
+            gdf_gestuurde_culvert.to_file(out, driver="GPKG", layer=layer_name)
 
-        return gdf_orifice
+        return gdf_gestuurde_culvert
 
     def run(self, overwrite: bool = False) -> gpd.GeoDataFrame:
         # Check overwrite
@@ -255,7 +259,7 @@ class StructureControl:
 
             self.save()
 
-            self.export_gestuurde_culvert()
+            self.export_gestuurde_duiker()
             return self.control_gdf
 
 

--- a/hhnk_threedi_tools/core/checks/schematisation/structure_control.py
+++ b/hhnk_threedi_tools/core/checks/schematisation/structure_control.py
@@ -5,7 +5,6 @@ import geopandas as gpd
 import hhnk_research_tools as hrt
 import numpy as np
 import pandas as pd
-
 from core.folders import Folders
 
 logger = hrt.logging.get_logger(name=__name__)
@@ -31,7 +30,13 @@ class StructureControl:
     #### TODO there is no check on the control logic in this class...
     """
 
-    def __init__(self, model: hrt.SpatialDatabase, hdb_control_layer: hrt.SpatialDatabaseLayer, output_file: str, output_orifice_file: None,):
+    def __init__(
+        self,
+        model: hrt.SpatialDatabase,
+        hdb_control_layer: hrt.SpatialDatabaseLayer,
+        output_file: str,
+        output_orifice_file: None,
+    ):
         self.model = model
         self.hdb_control_layer = hdb_control_layer
         self.output_file = Path(output_file)
@@ -218,7 +223,7 @@ class StructureControl:
 
         out = self.output_orifice_file
         create = hrt.check_create_new_file(output_file=out, overwrite=overwrite)
-        
+
         if create:
             gdf_orifice = self.control_gdf.loc[self.control_gdf["target_type"] == "v2_orifice"].copy()
             gdf_orifice = gpd.GeoDataFrame(gdf_orifice, geometry="geometry", crs=self.control_gdf.crs)
@@ -256,7 +261,7 @@ class StructureControl:
 
             self.export_gestuurde_orifice(overwrite=overwrite)
             return self.control_gdf
-        
+
 
 def create_sorted_actiontable_queries(database: hrt.SpatialDatabase) -> list[str]:
     """
@@ -326,12 +331,11 @@ def update_sorted_actiontable(database: hrt.SpatialDatabase, queries: list[str])
         database.modify_gpkg_using_query(query=query)
 
 
-
 # %%
 if __name__ == "__main__":
     for i in range(1, 5):
         TEST_MODEL = Path(__file__).parents[i].absolute() / "tests/data/model_test/"
-        TEST_MODEL = r'Y:\02.modellen\grootslag_leggertool'
+        TEST_MODEL = r"Y:\02.modellen\grootslag_leggertool"
         folder = Folders(TEST_MODEL)
         if folder.exists():
             break
@@ -340,7 +344,7 @@ if __name__ == "__main__":
         model=folder.model.schema_base.database,
         hdb_control_layer=folder.source_data.hdb.layers.sturing_kunstwerken,
         output_file=folder.output.hhnk_schematisation_checks.gestuurde_kunstwerken.path,
-        output_orifice_file=folder.output.hhnk_schematisation_checks.gestuurde_orifice.path, 
+        output_orifice_file=folder.output.hhnk_schematisation_checks.gestuurde_orifice.path,
     )
     self.run(overwrite=True)
 

--- a/hhnk_threedi_tools/core/checks/schematisation/structure_control.py
+++ b/hhnk_threedi_tools/core/checks/schematisation/structure_control.py
@@ -18,6 +18,7 @@ class StructureControl:
     Parameters
     ----------
     model: hrt.SpatialDatabase
+    
         SpatialDatabase object that is your model (gpkg), i.e. folder.model.schema_base.database
     hdb_control_layer: hrt.SpatialDatabaseLayer
         SpatialDatabase object that referes to the control table overview in the HDB, i.e. folder.source_data.hdb.layers.sturing_kunstwerken

--- a/hhnk_threedi_tools/core/checks/schematisation/structure_control.py
+++ b/hhnk_threedi_tools/core/checks/schematisation/structure_control.py
@@ -1,7 +1,6 @@
 # %%
 from pathlib import Path
 
-import fiona
 import geopandas as gpd
 import hhnk_research_tools as hrt
 import numpy as np
@@ -212,32 +211,6 @@ class StructureControl:
         self.control_gdf = gpd.GeoDataFrame(self.control_gdf)
         self.control_gdf.to_file(self.output_file)
 
-    def export_gestuurde_duiker(
-        self,
-    ) -> gpd.GeoDataFrame:
-        """
-        Export culvert to self.output_file.Uses the same geometry as self.control_gdf.
-        If there are none, writes an empty layer and logs info.
-        """
-        if self.output_file is None:
-            logger.debug("No output_file configured; skipping culvert export.")
-            return gpd.GeoDataFrame()
-
-        out = self.output_file
-        layer_name = "gestuurde_duiker"
-        gdf_gestuurde_culvert = self.control_gdf.loc[self.control_gdf["target_type"] == "culvert"].copy()
-
-        sturing_kunstwerken = hrt.SpatialDatabase(out)
-        available_layers = sturing_kunstwerken.available_layers()
-
-        if layer_name in available_layers:
-            logger.info(f"Overwriting existing layer '{layer_name}' in {out}.")
-        else:
-            logger.info(f"Creating new layer '{layer_name}' in {out}.")
-            gdf_gestuurde_culvert.to_file(out, driver="GPKG", layer=layer_name)
-
-        return gdf_gestuurde_culvert
-
     def run(self, overwrite: bool = False) -> gpd.GeoDataFrame:
         # Check overwrite
         create = hrt.check_create_new_file(output_file=self.output_file, overwrite=overwrite)
@@ -259,7 +232,6 @@ class StructureControl:
 
             self.save()
 
-            self.export_gestuurde_duiker()
             return self.control_gdf
 
 

--- a/hhnk_threedi_tools/core/folders.py
+++ b/hhnk_threedi_tools/core/folders.py
@@ -616,6 +616,7 @@ class OutputDirParent(Folder):
             self.add_file("gebruikte_profielen", "gebruikte_profielen.gpkg")
             self.add_file("geisoleerde_watergangen", "geisoleerde_watergangen.gpkg")
             self.add_file("gestuurde_kunstwerken", "gestuurde_kunstwerken.gpkg")
+            self.add_file("gestuurde_orifice", "gestuurde_orifice.gpkg")
             self.add_file("drooglegging", "drooglegging.tif")
             self.add_file("geometry_check", "geometry_check.csv")
             self.add_file("general_hhnk_schematisation_checks", "general_hhnk_schematisation_checks.csv")

--- a/hhnk_threedi_tools/core/folders.py
+++ b/hhnk_threedi_tools/core/folders.py
@@ -616,7 +616,6 @@ class OutputDirParent(Folder):
             self.add_file("gebruikte_profielen", "gebruikte_profielen.gpkg")
             self.add_file("geisoleerde_watergangen", "geisoleerde_watergangen.gpkg")
             self.add_file("gestuurde_kunstwerken", "gestuurde_kunstwerken.gpkg")
-            self.add_file("gestuurde_orifice", "gestuurde_orifice.gpkg")
             self.add_file("drooglegging", "drooglegging.tif")
             self.add_file("geometry_check", "geometry_check.csv")
             self.add_file("general_hhnk_schematisation_checks", "general_hhnk_schematisation_checks.csv")

--- a/hhnk_threedi_tools/resources/checks/sql_checks.py
+++ b/hhnk_threedi_tools/resources/checks/sql_checks.py
@@ -244,7 +244,7 @@ UNION ALL
 SELECT
 'table_control' as table_name,
 table_control.id as id,
-'warning: structure control does not work for culverts' as error 
+'ERROR: structure control does not work for culverts' as error 
 FROM table_control
 WHERE action_table IS NOT NULL 
 AND target_type LIKE 'culvert%';

--- a/hhnk_threedi_tools/resources/checks/sql_checks.py
+++ b/hhnk_threedi_tools/resources/checks/sql_checks.py
@@ -240,4 +240,12 @@ table_control.id as id,
 'ERROR: action_table has more than 1000 characters (model will crash)' as error
 FROM table_control
 WHERE length(table_control.action_table) > 1000
+UNION ALL
+SELECT
+'table_control' as table_name,
+table_control.id as id,
+'warning: structure control does not work for culverts' as error 
+FROM table_control
+WHERE action_table IS NOT NULL 
+AND target_type LIKE 'culvert%';
 """

--- a/hhnk_threedi_tools/resources/checks/sql_checks.py
+++ b/hhnk_threedi_tools/resources/checks/sql_checks.py
@@ -247,5 +247,13 @@ table_control.id as id,
 'ERROR: structure control does not work for culverts' as error 
 FROM table_control
 WHERE action_table IS NOT NULL 
-AND target_type LIKE 'culvert%';
+AND target_type LIKE 'culvert%'
+UNION ALL
+SELECT 'impervious_surface_map' AS impervious_surface_map,
+0 AS id,
+'ERROR: impervious_surface_map is empty' AS message
+WHERE (
+SELECT COUNT(*)
+FROM impervious_surface_map
+) = 0;
 """

--- a/tests/test_hhnk_schematisation_checks.py
+++ b/tests/test_hhnk_schematisation_checks.py
@@ -47,6 +47,17 @@ class TestSchematisation:
 
         output_df = output_file.load()
         assert output_df["hdb_kruin_max"][0] == -0.25
+    
+    def test_structure_control_no_culverts(self, hhnk_schematisation_checks):
+        output = hhnk_schematisation_checks.run_model_checks()
+
+        culvert_structure_control = output["error"].str.contains(
+            "warning: structure control does not work for culverts",
+            case=False,
+            na=False,
+        )
+        assert output.loc[culvert_structure_control].empty
+
 
     def test_run_dem_max_value(self, hhnk_schematisation_checks):
         output = hhnk_schematisation_checks.run_dem_max_value()

--- a/tests/test_hhnk_schematisation_checks.py
+++ b/tests/test_hhnk_schematisation_checks.py
@@ -48,16 +48,6 @@ class TestSchematisation:
         output_df = output_file.load()
         assert output_df["hdb_kruin_max"][0] == -0.25
 
-    def test_structure_control_no_culverts(self, hhnk_schematisation_checks):
-        output = hhnk_schematisation_checks.run_model_checks()
-
-        culvert_structure_control = output["error"].str.contains(
-            "warning: structure control does not work for culverts",
-            case=False,
-            na=False,
-        )
-        assert output.loc[culvert_structure_control].empty
-
     def test_run_dem_max_value(self, hhnk_schematisation_checks):
         output = hhnk_schematisation_checks.run_dem_max_value()
         assert "voldoet aan de norm" in output
@@ -154,5 +144,4 @@ if __name__ == "__main__":
     # self.test_run_cross_section_duplicates(folder_new=folder_new)
     # self.test_run_cross_section_no_vertex(folder_new=folder_new)
     self.test_run_geometry()
-
 # %%

--- a/tests/test_hhnk_schematisation_checks.py
+++ b/tests/test_hhnk_schematisation_checks.py
@@ -47,7 +47,7 @@ class TestSchematisation:
 
         output_df = output_file.load()
         assert output_df["hdb_kruin_max"][0] == -0.25
-    
+
     def test_structure_control_no_culverts(self, hhnk_schematisation_checks):
         output = hhnk_schematisation_checks.run_model_checks()
 
@@ -57,7 +57,6 @@ class TestSchematisation:
             na=False,
         )
         assert output.loc[culvert_structure_control].empty
-
 
     def test_run_dem_max_value(self, hhnk_schematisation_checks):
         output = hhnk_schematisation_checks.run_dem_max_value()


### PR DESCRIPTION
1. Define the initialization from Structure control class as ruff. 
2. Create the function export_gestuurde_culvert in the structure control class to save separetely the culverts that are in the gestuurde_kunstwerken geopackge and save that layer with the name gestuurde_culvert.
3. Correct typo in schematisation_checks_main. leayer -> layer
4. Add to the sql_check the subset that selects the id, from the table_control that corresponds to target type culvert% and set a warning message as error  'warning: structure control does not work for culverts'
5. Create function  def test_structure_control_no_culverts(self, hhnk_schematisation_checks). Return empty because there is no culvert in the data test.